### PR TITLE
feat: remove user-configurable backend, state managed by Lace Cloud

### DIFF
--- a/src/chat/tools/graph-read-tools.ts
+++ b/src/chat/tools/graph-read-tools.ts
@@ -231,11 +231,7 @@ export function registerGraphReadTools(deps: GraphReadDeps): void {
       } else {
         lines.push('- required_providers: (none)');
       }
-      if (settings.terraform.backend) {
-        lines.push(`- backend: type=${settings.terraform.backend.type}`);
-      } else {
-        lines.push('- backend: (not configured)');
-      }
+      lines.push('- backend: managed by Lace Cloud (HTTP)');
 
       lines.push('');
       lines.push('### Providers');

--- a/src/utilities/engine/grpc-client.ts
+++ b/src/utilities/engine/grpc-client.ts
@@ -253,9 +253,6 @@ function convertSettingsConfig(proto: ProtoSettingsConfig): SettingsConfig {
         source: p.source,
         version: p.version,
       })),
-      backend: proto.terraform?.backend
-        ? { type: proto.terraform.backend.type, config: proto.terraform.backend.config ?? {} }
-        : undefined,
     },
     providers: proto.providers.map((p) => ({
       name: p.name,
@@ -268,12 +265,6 @@ function convertSettingsConfig(proto: ProtoSettingsConfig): SettingsConfig {
       value_display: l.value_display,
     })),
     environments: (proto.environments ?? {}) as Record<string, Record<string, unknown>>,
-    environment_backends: Object.fromEntries(
-      Object.entries(proto.environment_backends ?? {}).map(([k, v]) => [
-        k,
-        { type: v.type, config: v.config ?? {} },
-      ]),
-    ),
   };
 }
 
@@ -751,7 +742,6 @@ export class LaceClient {
   async setTerraform(params: {
     required_version?: string;
     required_providers?: Array<{ name: string; source: string; version: string }>;
-    backend?: { type: string; config: Record<string, unknown> };
   }): Promise<Record<string, never>> {
     const requiredProviders: ProviderReqView[] = (params.required_providers ?? []).map((p) => ({
       name: p.name,
@@ -768,9 +758,7 @@ export class LaceClient {
     >(this.inner.setTerraform, {
       required_version: params.required_version ?? '',
       required_providers: requiredProviders,
-      backend: params.backend
-        ? { type: params.backend.type, config: params.backend.config }
-        : undefined,
+      backend: undefined,
     });
     return {};
   }
@@ -820,9 +808,14 @@ export class LaceClient {
 
   async setEnvironments(params: {
     environments: Record<string, Record<string, unknown>>;
-    environment_backends: Record<string, { type: string; config: Record<string, unknown> }>;
   }): Promise<Record<string, never>> {
-    await this.unary<typeof params, Empty>(this.inner.setEnvironments, params);
+    await this.unary<
+      {
+        environments: Record<string, Record<string, unknown>>;
+        environment_backends: Record<string, never>;
+      },
+      Empty
+    >(this.inner.setEnvironments, { environments: params.environments, environment_backends: {} });
     return {};
   }
 
@@ -978,7 +971,6 @@ export class LaceClient {
           params as {
             required_version?: string;
             required_providers?: Array<{ name: string; source: string; version: string }>;
-            backend?: { type: string; config: Record<string, unknown> };
           },
         );
       case 'action/set_providers':
@@ -1005,7 +997,6 @@ export class LaceClient {
         return this.setEnvironments(
           params as {
             environments: Record<string, Record<string, unknown>>;
-            environment_backends: Record<string, { type: string; config: Record<string, unknown> }>;
           },
         );
       case 'action/undo':

--- a/src/webview/Canvas.tsx
+++ b/src/webview/Canvas.tsx
@@ -307,6 +307,7 @@ function CompositeEditor({
         markerEnd: { type: MarkerType.ArrowClosed, color: '#CEFE65', width: 16, height: 16 },
         style: { stroke: '#CEFE65', strokeWidth: 1.5 },
       }}
+      connectionRadius={25}
       minZoom={0.1}
       maxZoom={4}
       selectNodesOnDrag={false}
@@ -359,6 +360,10 @@ function CompositeEditor({
 
 export default function Canvas() {
   const { state, engine, updateView } = useCanvas();
+
+  // Ref to always read the latest view (avoids stale closures in async callbacks)
+  const viewRef = useRef(state.view);
+  viewRef.current = state.view;
 
   const [configTarget, setConfigTarget] = useState<string | null>(null);
   const [newNodeIds, setNewNodeIds] = useState<Set<string>>(new Set());
@@ -633,22 +638,34 @@ export default function Canvas() {
     async (conn: Connection) => {
       if (!conn.source || !conn.target || !engine) return;
 
-      const edgesBefore = state.view?.edges.length ?? 0;
+      // Snapshot edge IDs between this pair using ref for freshest state.
+      // Using a ref avoids stale closures when edges change between
+      // callback creation and invocation (e.g. concurrent disconnect).
+      const prevPairEdgeIds = new Set(
+        (viewRef.current?.edges ?? [])
+          .filter((e) => e.source === conn.source && e.target === conn.target)
+          .map((e) => e.id),
+      );
 
       try {
         const result = await engine.autoConnect(conn.source, conn.target);
-        const edgesAfter = result.edges?.length ?? 0;
 
-        if (edgesAfter > edgesBefore) {
+        // Check if auto-connect created any NEW edge between these nodes
+        const hasNewEdge = (result.edges ?? []).some(
+          (e) => e.source === conn.source && e.target === conn.target && !prevPairEdgeIds.has(e.id),
+        );
+
+        if (hasNewEdge) {
           updateView(result);
         } else {
           setEdgeConfigState({ source: conn.source, target: conn.target });
         }
-      } catch {
+      } catch (err) {
+        console.error('[Canvas] autoConnect failed:', err);
         setEdgeConfigState({ source: conn.source, target: conn.target });
       }
     },
-    [engine, state.view?.edges.length, updateView, clearNew],
+    [engine, updateView],
   );
 
   // ── Event: edge delete (select edge + Delete/Backspace) ──
@@ -663,7 +680,7 @@ export default function Canvas() {
         }
       }
     },
-    [engine, updateView, clearNew],
+    [engine, updateView],
   );
 
   // ── Event: node delete (select node + Delete/Backspace) ──
@@ -675,7 +692,7 @@ export default function Canvas() {
         updateView(result);
       }
     },
-    [engine, updateView, clearNew],
+    [engine, updateView],
   );
 
   // ── Event: clear all modules from graph ──
@@ -702,7 +719,7 @@ export default function Canvas() {
       updateView(result);
       setEdgeConfigState(null);
     },
-    [engine, updateView, clearNew],
+    [engine, updateView],
   );
 
   useEffect(() => {

--- a/src/webview/Canvas.tsx
+++ b/src/webview/Canvas.tsx
@@ -582,22 +582,28 @@ export default function Canvas() {
       return;
     }
     const ids = clipboardRef.current;
-    const prevIds = new Set((state.view?.nodes ?? []).map((n) => n.id));
-    const result = await engine.copyInstances(ids);
-    const newIds = result.nodes
-      .filter((n: { id: string }) => !prevIds.has(n.id) && !ids.includes(n.id))
-      .map((n: { id: string }) => n.id);
-    if (newIds.length > 0) {
-      selectNodesRef.current?.(newIds);
-    }
-    updateView(result);
-    if (isCutRef.current) {
-      for (const id of ids) {
-        const r = await engine.deleteInstance(id);
-        updateView(r);
+    try {
+      const prevIds = new Set((state.view?.nodes ?? []).map((n) => n.id));
+      const result = await engine.copyInstances(ids);
+      const newIds = result.nodes
+        .filter((n: { id: string }) => !prevIds.has(n.id) && !ids.includes(n.id))
+        .map((n: { id: string }) => n.id);
+      if (newIds.length > 0) {
+        selectNodesRef.current?.(newIds);
       }
-      clipboardRef.current = [];
-      isCutRef.current = false;
+      updateView(result);
+      if (isCutRef.current) {
+        for (const id of ids) {
+          const r = await engine.deleteInstance(id);
+          updateView(r);
+        }
+        clipboardRef.current = [];
+        isCutRef.current = false;
+      }
+    } catch (err) {
+      console.error('[Canvas] paste failed:', err);
+      setToast({ message: 'Paste failed — try again', type: 'error' });
+      setTimeout(() => setToast(null), TOAST_BRIEF);
     }
   }, [engine, updateView, state.view]);
 

--- a/src/webview/components/panels/EnvironmentsPanel.tsx
+++ b/src/webview/components/panels/EnvironmentsPanel.tsx
@@ -3,6 +3,9 @@ import React, { useState, useCallback } from 'react';
 import {
   inputClasses,
   saveButtonClasses,
+  saveButtonSavingClasses,
+  saveButtonSuccessClasses,
+  saveButtonErrorClasses,
   removeButtonClasses,
   removeButtonSmClasses,
   addButtonClasses,
@@ -48,9 +51,11 @@ function fromEnvRows(rows: EnvRow[]): Record<string, Record<string, unknown>> {
 
 // ── Content-only component (used by UnifiedSettingsPanel) ──
 
+type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
+
 type ContentProps = {
   environments: Record<string, Record<string, unknown>> | undefined;
-  onSave: (environments: Record<string, Record<string, unknown>>) => void;
+  onSave: (environments: Record<string, Record<string, unknown>>) => void | Promise<void>;
 };
 
 export function EnvironmentsContent({ environments, onSave }: ContentProps) {
@@ -137,9 +142,19 @@ export function EnvironmentsContent({ environments, onSave }: ContentProps) {
 
   // ── Save ──
 
-  const handleSave = () => {
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
+
+  const handleSave = async () => {
     if (hasDuplicates) return;
-    onSave(fromEnvRows(envRows));
+    setSaveStatus('saving');
+    try {
+      await onSave(fromEnvRows(envRows));
+      setSaveStatus('saved');
+      setTimeout(() => setSaveStatus('idle'), 1500);
+    } catch {
+      setSaveStatus('error');
+      setTimeout(() => setSaveStatus('idle'), 2000);
+    }
   };
 
   return (
@@ -193,13 +208,27 @@ export function EnvironmentsContent({ environments, onSave }: ContentProps) {
 
       {/* Inline save */}
       <button
-        className={saveButtonClasses}
+        className={
+          saveStatus === 'saving'
+            ? saveButtonSavingClasses
+            : saveStatus === 'saved'
+              ? saveButtonSuccessClasses
+              : saveStatus === 'error'
+                ? saveButtonErrorClasses
+                : saveButtonClasses
+        }
         onClick={handleSave}
-        disabled={hasDuplicates}
+        disabled={hasDuplicates || saveStatus === 'saving'}
         title={hasDuplicates ? 'Fix duplicate names before saving' : undefined}
         style={hasDuplicates ? { opacity: 0.5, cursor: 'not-allowed' } : undefined}
       >
-        Save environments
+        {saveStatus === 'saving'
+          ? 'Saving...'
+          : saveStatus === 'saved'
+            ? 'Saved!'
+            : saveStatus === 'error'
+              ? 'Save failed — try again'
+              : 'Save environments'}
       </button>
       {hasDuplicates && (
         <div className="text-[10px] text-[#e5484d] mt-1">
@@ -214,7 +243,7 @@ export function EnvironmentsContent({ environments, onSave }: ContentProps) {
 
 type Props = {
   environments: Record<string, Record<string, unknown>> | undefined;
-  onSave: (environments: Record<string, Record<string, unknown>>) => void;
+  onSave: (environments: Record<string, Record<string, unknown>>) => void | Promise<void>;
   onClose: () => void;
 };
 

--- a/src/webview/components/panels/EnvironmentsPanel.tsx
+++ b/src/webview/components/panels/EnvironmentsPanel.tsx
@@ -2,7 +2,6 @@
 import React, { useState, useCallback } from 'react';
 import {
   inputClasses,
-  BACKEND_TYPES,
   saveButtonClasses,
   removeButtonClasses,
   removeButtonSmClasses,
@@ -10,27 +9,12 @@ import {
   addButtonSmClasses,
   rowCardClasses,
 } from '../../styles/panel';
-import { parseConfigValue } from '../../utils/parseValue';
 import PanelFrame from '../PanelFrame';
-
-// ── Types derived from SettingsConfig ──
-
-type BackendConfigEntry = { type: string; config: Record<string, unknown> };
-
-// ── Shared styles ──
-
-const tabClasses =
-  'px-3 py-1.5 text-xs cursor-pointer border-none rounded-t-md transition-colors duration-100';
 
 // ── Local editing state ──
 
 type EnvVarEntry = { key: string; value: string };
 type EnvRow = { name: string; vars: EnvVarEntry[] };
-type BackendRow = {
-  envName: string;
-  type: string;
-  config: Array<{ key: string; value: string }>;
-};
 
 function toEnvRows(envs: Record<string, Record<string, unknown>> | undefined): EnvRow[] {
   if (!envs) return [];
@@ -39,18 +23,6 @@ function toEnvRows(envs: Record<string, Record<string, unknown>> | undefined): E
     vars: Object.entries(vars).map(([key, value]) => ({
       key,
       value: typeof value === 'object' ? JSON.stringify(value) : String(value),
-    })),
-  }));
-}
-
-function toBackendRows(backends: Record<string, BackendConfigEntry> | undefined): BackendRow[] {
-  if (!backends) return [];
-  return Object.entries(backends).map(([envName, backend]) => ({
-    envName,
-    type: backend.type,
-    config: Object.entries(backend.config).map(([key, value]) => ({
-      key,
-      value: typeof value === 'boolean' ? String(value) : String(value),
     })),
   }));
 }
@@ -74,37 +46,15 @@ function fromEnvRows(rows: EnvRow[]): Record<string, Record<string, unknown>> {
   return result;
 }
 
-function fromBackendRows(rows: BackendRow[]): Record<string, BackendConfigEntry> {
-  const result: Record<string, BackendConfigEntry> = {};
-  for (const row of rows) {
-    if (!row.envName.trim()) continue;
-    const config: Record<string, unknown> = {};
-    for (const c of row.config) {
-      if (!c.key.trim()) continue;
-      config[c.key.trim()] = parseConfigValue(c.value);
-    }
-    result[row.envName.trim()] = { type: row.type, config };
-  }
-  return result;
-}
-
 // ── Content-only component (used by UnifiedSettingsPanel) ──
 
 type ContentProps = {
   environments: Record<string, Record<string, unknown>> | undefined;
-  environment_backends: Record<string, BackendConfigEntry> | undefined;
-  onSave: (
-    environments: Record<string, Record<string, unknown>>,
-    backends: Record<string, BackendConfigEntry>,
-  ) => void;
+  onSave: (environments: Record<string, Record<string, unknown>>) => void;
 };
 
-export function EnvironmentsContent({ environments, environment_backends, onSave }: ContentProps) {
-  const [activeTab, setActiveTab] = useState<'environments' | 'backends'>('environments');
+export function EnvironmentsContent({ environments, onSave }: ContentProps) {
   const [envRows, setEnvRows] = useState<EnvRow[]>(() => toEnvRows(environments));
-  const [backendRows, setBackendRows] = useState<BackendRow[]>(() =>
-    toBackendRows(environment_backends),
-  );
 
   // ── Environment editing ──
 
@@ -152,61 +102,6 @@ export function EnvironmentsContent({ environments, environment_backends, onSave
     [],
   );
 
-  // ── Backend editing ──
-
-  const addBackend = useCallback(() => {
-    setBackendRows((prev) => [
-      ...prev,
-      { envName: '', type: 's3', config: [{ key: '', value: '' }] },
-    ]);
-  }, []);
-
-  const removeBackend = useCallback((index: number) => {
-    setBackendRows((prev) => prev.filter((_, i) => i !== index));
-  }, []);
-
-  const updateBackendEnvName = useCallback((index: number, envName: string) => {
-    setBackendRows((prev) => prev.map((r, i) => (i === index ? { ...r, envName } : r)));
-  }, []);
-
-  const updateBackendType = useCallback((index: number, type: string) => {
-    setBackendRows((prev) => prev.map((r, i) => (i === index ? { ...r, type } : r)));
-  }, []);
-
-  const addBackendConfig = useCallback((backendIndex: number) => {
-    setBackendRows((prev) =>
-      prev.map((r, i) =>
-        i === backendIndex ? { ...r, config: [...r.config, { key: '', value: '' }] } : r,
-      ),
-    );
-  }, []);
-
-  const removeBackendConfig = useCallback((backendIndex: number, configIndex: number) => {
-    setBackendRows((prev) =>
-      prev.map((r, i) =>
-        i === backendIndex ? { ...r, config: r.config.filter((_, ci) => ci !== configIndex) } : r,
-      ),
-    );
-  }, []);
-
-  const updateBackendConfig = useCallback(
-    (backendIndex: number, configIndex: number, field: 'key' | 'value', value: string) => {
-      setBackendRows((prev) =>
-        prev.map((r, i) =>
-          i === backendIndex
-            ? {
-                ...r,
-                config: r.config.map((c, ci) =>
-                  ci === configIndex ? { ...c, [field]: value } : c,
-                ),
-              }
-            : r,
-        ),
-      );
-    },
-    [],
-  );
-
   // ── Validation: duplicate detection ──
 
   // Duplicate environment names
@@ -244,138 +139,57 @@ export function EnvironmentsContent({ environments, environment_backends, onSave
 
   const handleSave = () => {
     if (hasDuplicates) return;
-    onSave(fromEnvRows(envRows), fromBackendRows(backendRows));
+    onSave(fromEnvRows(envRows));
   };
 
   return (
     <>
-      {/* Tabs */}
-      <div className="flex border-b border-[#333] mb-3 -mx-4 px-4">
-        <button
-          className={`${tabClasses} ${activeTab === 'environments' ? 'bg-[#1e1e1e] text-white' : 'bg-transparent text-[#999]'}`}
-          onClick={() => setActiveTab('environments')}
-        >
-          Environments
-        </button>
-        <button
-          className={`${tabClasses} ${activeTab === 'backends' ? 'bg-[#1e1e1e] text-white' : 'bg-transparent text-[#999]'}`}
-          onClick={() => setActiveTab('backends')}
-        >
-          Backends
-        </button>
-      </div>
+      {envRows.map((env, ei) => (
+        <div key={ei} className={rowCardClasses}>
+          <div className="flex gap-2 mb-1">
+            <input
+              value={env.name}
+              onChange={(e) => updateEnvName(ei, e.target.value)}
+              placeholder="Environment name (e.g. dev)"
+              className={`${inputClasses} flex-1 font-bold ${envNameDupes.has(ei) ? 'border-[#e5484d]' : ''}`}
+            />
+            <button onClick={() => removeEnv(ei)} className={removeButtonClasses}>
+              ✕
+            </button>
+          </div>
+          {envNameDupes.has(ei) && (
+            <div className="text-[10px] text-[#e5484d] mb-2">Duplicate environment name</div>
+          )}
 
-      {activeTab === 'environments' && (
-        <>
-          {envRows.map((env, ei) => (
-            <div key={ei} className={rowCardClasses}>
-              <div className="flex gap-2 mb-1">
-                <input
-                  value={env.name}
-                  onChange={(e) => updateEnvName(ei, e.target.value)}
-                  placeholder="Environment name (e.g. dev)"
-                  className={`${inputClasses} flex-1 font-bold ${envNameDupes.has(ei) ? 'border-[#e5484d]' : ''}`}
-                />
-                <button onClick={() => removeEnv(ei)} className={removeButtonClasses}>
-                  ✕
-                </button>
-              </div>
-              {envNameDupes.has(ei) && (
-                <div className="text-[10px] text-[#e5484d] mb-2">Duplicate environment name</div>
-              )}
-
-              <div className="text-[11px] opacity-70 mb-2">Variable overrides</div>
-              {env.vars.map((v, vi) => (
-                <div key={vi} className="flex gap-2 mb-1.5">
-                  <input
-                    value={v.key}
-                    onChange={(e) => updateEnvVar(ei, vi, 'key', e.target.value)}
-                    placeholder="Variable name"
-                    className={`${inputClasses} flex-1 ${envVarDupes[ei]?.has(vi) ? 'border-[#e5484d]' : ''}`}
-                    title={envVarDupes[ei]?.has(vi) ? 'Duplicate variable name' : undefined}
-                  />
-                  <input
-                    value={v.value}
-                    onChange={(e) => updateEnvVar(ei, vi, 'value', e.target.value)}
-                    placeholder="Value"
-                    className={`${inputClasses} flex-1`}
-                  />
-                  <button onClick={() => removeEnvVar(ei, vi)} className={removeButtonSmClasses}>
-                    ✕
-                  </button>
-                </div>
-              ))}
-              <button onClick={() => addEnvVar(ei)} className={addButtonSmClasses}>
-                + Add variable
+          <div className="text-[11px] opacity-70 mb-2">Variable overrides</div>
+          {env.vars.map((v, vi) => (
+            <div key={vi} className="flex gap-2 mb-1.5">
+              <input
+                value={v.key}
+                onChange={(e) => updateEnvVar(ei, vi, 'key', e.target.value)}
+                placeholder="Variable name"
+                className={`${inputClasses} flex-1 ${envVarDupes[ei]?.has(vi) ? 'border-[#e5484d]' : ''}`}
+                title={envVarDupes[ei]?.has(vi) ? 'Duplicate variable name' : undefined}
+              />
+              <input
+                value={v.value}
+                onChange={(e) => updateEnvVar(ei, vi, 'value', e.target.value)}
+                placeholder="Value"
+                className={`${inputClasses} flex-1`}
+              />
+              <button onClick={() => removeEnvVar(ei, vi)} className={removeButtonSmClasses}>
+                ✕
               </button>
             </div>
           ))}
-          <button onClick={addEnv} className={addButtonClasses}>
-            + Add environment
+          <button onClick={() => addEnvVar(ei)} className={addButtonSmClasses}>
+            + Add variable
           </button>
-        </>
-      )}
-
-      {activeTab === 'backends' && (
-        <>
-          {backendRows.map((b, bi) => (
-            <div key={bi} className={rowCardClasses}>
-              <div className="flex gap-2 mb-2">
-                <input
-                  value={b.envName}
-                  onChange={(e) => updateBackendEnvName(bi, e.target.value)}
-                  placeholder="Environment name"
-                  className={`${inputClasses} flex-1 font-bold`}
-                />
-                <select
-                  value={b.type}
-                  onChange={(e) => updateBackendType(bi, e.target.value)}
-                  className={`${inputClasses} flex-1`}
-                >
-                  {BACKEND_TYPES.map((t) => (
-                    <option key={t} value={t}>
-                      {t}
-                    </option>
-                  ))}
-                </select>
-                <button onClick={() => removeBackend(bi)} className={removeButtonClasses}>
-                  ✕
-                </button>
-              </div>
-
-              <div className="text-[11px] opacity-70 mb-2">Config</div>
-              {b.config.map((c, ci) => (
-                <div key={ci} className="flex gap-2 mb-1.5">
-                  <input
-                    value={c.key}
-                    onChange={(e) => updateBackendConfig(bi, ci, 'key', e.target.value)}
-                    placeholder="Key"
-                    className={`${inputClasses} flex-1`}
-                  />
-                  <input
-                    value={c.value}
-                    onChange={(e) => updateBackendConfig(bi, ci, 'value', e.target.value)}
-                    placeholder="Value"
-                    className={`${inputClasses} flex-1`}
-                  />
-                  <button
-                    onClick={() => removeBackendConfig(bi, ci)}
-                    className={removeButtonSmClasses}
-                  >
-                    ✕
-                  </button>
-                </div>
-              ))}
-              <button onClick={() => addBackendConfig(bi)} className={addButtonSmClasses}>
-                + Add config key
-              </button>
-            </div>
-          ))}
-          <button onClick={addBackend} className={addButtonClasses}>
-            + Add backend
-          </button>
-        </>
-      )}
+        </div>
+      ))}
+      <button onClick={addEnv} className={addButtonClasses}>
+        + Add environment
+      </button>
 
       {/* Inline save */}
       <button
@@ -400,27 +214,14 @@ export function EnvironmentsContent({ environments, environment_backends, onSave
 
 type Props = {
   environments: Record<string, Record<string, unknown>> | undefined;
-  environment_backends: Record<string, BackendConfigEntry> | undefined;
-  onSave: (
-    environments: Record<string, Record<string, unknown>>,
-    backends: Record<string, BackendConfigEntry>,
-  ) => void;
+  onSave: (environments: Record<string, Record<string, unknown>>) => void;
   onClose: () => void;
 };
 
-export default function EnvironmentsPanel({
-  environments,
-  environment_backends,
-  onSave,
-  onClose,
-}: Props) {
+export default function EnvironmentsPanel({ environments, onSave, onClose }: Props) {
   return (
     <PanelFrame title="Environments" onClose={onClose}>
-      <EnvironmentsContent
-        environments={environments}
-        environment_backends={environment_backends}
-        onSave={onSave}
-      />
+      <EnvironmentsContent environments={environments} onSave={onSave} />
     </PanelFrame>
   );
 }

--- a/src/webview/components/panels/LocalsPanel.tsx
+++ b/src/webview/components/panels/LocalsPanel.tsx
@@ -8,6 +8,9 @@ import {
   modeButtonActive,
   modeButtonInactive,
   saveButtonClasses,
+  saveButtonSavingClasses,
+  saveButtonSuccessClasses,
+  saveButtonErrorClasses,
   removeButtonClasses,
   addButtonClasses,
   rowCardClasses,
@@ -51,9 +54,11 @@ function fromRows(rows: LocalRow[]): LocalEntry[] {
 
 // ── Content-only component (used by UnifiedSettingsPanel) ──
 
+type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
+
 type ContentProps = {
   locals: LocalEntry[] | undefined;
-  onSave: (locals: LocalEntry[]) => void;
+  onSave: (locals: LocalEntry[]) => void | Promise<void>;
 };
 
 export function LocalsContent({ locals, onSave }: ContentProps) {
@@ -83,9 +88,19 @@ export function LocalsContent({ locals, onSave }: ContentProps) {
     setRows((prev) => prev.map((r, i) => (i === index ? { ...r, exprValue } : r)));
   }, []);
 
-  const handleSave = () => {
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
+
+  const handleSave = async () => {
     if (hasErrors) return;
-    onSave(fromRows(rows));
+    setSaveStatus('saving');
+    try {
+      await onSave(fromRows(rows));
+      setSaveStatus('saved');
+      setTimeout(() => setSaveStatus('idle'), 1500);
+    } catch {
+      setSaveStatus('error');
+      setTimeout(() => setSaveStatus('idle'), 2000);
+    }
   };
 
   // ── Validation ──
@@ -173,13 +188,27 @@ export function LocalsContent({ locals, onSave }: ContentProps) {
 
       {/* Inline save */}
       <button
-        className={saveButtonClasses}
+        className={
+          saveStatus === 'saving'
+            ? saveButtonSavingClasses
+            : saveStatus === 'saved'
+              ? saveButtonSuccessClasses
+              : saveStatus === 'error'
+                ? saveButtonErrorClasses
+                : saveButtonClasses
+        }
         onClick={handleSave}
-        disabled={hasErrors}
+        disabled={hasErrors || saveStatus === 'saving'}
         title={hasErrors ? 'Fix errors before saving' : undefined}
         style={hasErrors ? { opacity: 0.5, cursor: 'not-allowed' } : undefined}
       >
-        Save locals
+        {saveStatus === 'saving'
+          ? 'Saving...'
+          : saveStatus === 'saved'
+            ? 'Saved!'
+            : saveStatus === 'error'
+              ? 'Save failed — try again'
+              : 'Save locals'}
       </button>
     </>
   );
@@ -189,7 +218,7 @@ export function LocalsContent({ locals, onSave }: ContentProps) {
 
 type Props = {
   locals: LocalEntry[] | undefined;
-  onSave: (locals: LocalEntry[]) => void;
+  onSave: (locals: LocalEntry[]) => void | Promise<void>;
   onClose: () => void;
 };
 

--- a/src/webview/components/panels/ProvidersPanel.tsx
+++ b/src/webview/components/panels/ProvidersPanel.tsx
@@ -4,6 +4,9 @@ import type { SettingsConfig } from '../../types/render';
 import {
   inputClasses,
   saveButtonClasses,
+  saveButtonSavingClasses,
+  saveButtonSuccessClasses,
+  saveButtonErrorClasses,
   removeButtonClasses,
   removeButtonSmClasses,
   addButtonClasses,
@@ -56,9 +59,11 @@ function fromRows(rows: ProviderRow[]): ProviderEntry[] {
 
 // ── Content-only component (used by UnifiedSettingsPanel) ──
 
+type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
+
 type ContentProps = {
   providers: ProviderEntry[] | undefined;
-  onSave: (providers: ProviderEntry[]) => void;
+  onSave: (providers: ProviderEntry[]) => void | Promise<void>;
 };
 
 export function ProvidersContent({ providers, onSave }: ContentProps) {
@@ -114,8 +119,18 @@ export function ProvidersContent({ providers, onSave }: ContentProps) {
     [],
   );
 
-  const handleSave = () => {
-    onSave(fromRows(rows));
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
+
+  const handleSave = async () => {
+    setSaveStatus('saving');
+    try {
+      await onSave(fromRows(rows));
+      setSaveStatus('saved');
+      setTimeout(() => setSaveStatus('idle'), 1500);
+    } catch {
+      setSaveStatus('error');
+      setTimeout(() => setSaveStatus('idle'), 2000);
+    }
   };
 
   return (
@@ -171,8 +186,26 @@ export function ProvidersContent({ providers, onSave }: ContentProps) {
       </button>
 
       {/* Inline save */}
-      <button className={saveButtonClasses} onClick={handleSave}>
-        Save providers
+      <button
+        className={
+          saveStatus === 'saving'
+            ? saveButtonSavingClasses
+            : saveStatus === 'saved'
+              ? saveButtonSuccessClasses
+              : saveStatus === 'error'
+                ? saveButtonErrorClasses
+                : saveButtonClasses
+        }
+        onClick={handleSave}
+        disabled={saveStatus === 'saving'}
+      >
+        {saveStatus === 'saving'
+          ? 'Saving...'
+          : saveStatus === 'saved'
+            ? 'Saved!'
+            : saveStatus === 'error'
+              ? 'Save failed — try again'
+              : 'Save providers'}
       </button>
     </>
   );
@@ -182,7 +215,7 @@ export function ProvidersContent({ providers, onSave }: ContentProps) {
 
 type Props = {
   providers: ProviderEntry[] | undefined;
-  onSave: (providers: ProviderEntry[]) => void;
+  onSave: (providers: ProviderEntry[]) => void | Promise<void>;
   onClose: () => void;
 };
 

--- a/src/webview/components/panels/TerraformConfigPanel.tsx
+++ b/src/webview/components/panels/TerraformConfigPanel.tsx
@@ -3,12 +3,10 @@ import React, { useState, useCallback } from 'react';
 import type { SettingsConfig } from '../../types/render';
 import {
   inputClasses,
-  BACKEND_TYPES,
   saveButtonClasses,
   removeButtonClasses,
   addButtonClasses,
 } from '../../styles/panel';
-import { parseConfigValue } from '../../utils/parseValue';
 import PanelFrame from '../PanelFrame';
 
 // ── Types derived from SettingsConfig ──
@@ -35,15 +33,6 @@ export function TerraformConfigContent({ terraform, onSave }: ContentProps) {
     }));
   });
 
-  const [backendType, setBackendType] = useState(terraform?.backend?.type ?? 's3');
-  const [backendConfig, setBackendConfig] = useState<Array<{ key: string; value: string }>>(() => {
-    if (!terraform?.backend?.config) return [];
-    return Object.entries(terraform.backend.config).map(([key, value]) => ({
-      key,
-      value: typeof value === 'boolean' ? String(value) : String(value),
-    }));
-  });
-
   // ── Provider rows ──
 
   const addProvider = useCallback(() => {
@@ -61,20 +50,6 @@ export function TerraformConfigContent({ terraform, onSave }: ContentProps) {
     [],
   );
 
-  // ── Backend config rows ──
-
-  const addBackendKey = useCallback(() => {
-    setBackendConfig((prev) => [...prev, { key: '', value: '' }]);
-  }, []);
-
-  const removeBackendKey = useCallback((index: number) => {
-    setBackendConfig((prev) => prev.filter((_, i) => i !== index));
-  }, []);
-
-  const updateBackendKey = useCallback((index: number, field: 'key' | 'value', value: string) => {
-    setBackendConfig((prev) => prev.map((c, i) => (i === index ? { ...c, [field]: value } : c)));
-  }, []);
-
   // ── Save ──
 
   const handleSave = () => {
@@ -88,16 +63,6 @@ export function TerraformConfigContent({ terraform, onSave }: ContentProps) {
           version: p.version.trim(),
         })),
     };
-
-    if (backendConfig.length > 0) {
-      const config: Record<string, unknown> = {};
-      for (const c of backendConfig) {
-        if (c.key.trim()) {
-          config[c.key.trim()] = parseConfigValue(c.value);
-        }
-      }
-      block.backend = { type: backendType, config };
-    }
 
     onSave(block);
   };
@@ -146,42 +111,12 @@ export function TerraformConfigContent({ terraform, onSave }: ContentProps) {
         + Add provider
       </button>
 
-      {/* Backend */}
+      {/* Backend — managed by Lace */}
       <SectionTitle label="Backend" />
-      <select
-        value={backendType}
-        onChange={(e) => setBackendType(e.target.value)}
-        className={`${inputClasses} mb-3`}
-      >
-        {BACKEND_TYPES.map((t) => (
-          <option key={t} value={t}>
-            {t}
-          </option>
-        ))}
-      </select>
-
-      {backendConfig.map((c, i) => (
-        <div key={i} className="flex gap-2 mb-2">
-          <input
-            value={c.key}
-            onChange={(e) => updateBackendKey(i, 'key', e.target.value)}
-            placeholder="Key"
-            className={`${inputClasses} flex-1`}
-          />
-          <input
-            value={c.value}
-            onChange={(e) => updateBackendKey(i, 'value', e.target.value)}
-            placeholder="Value"
-            className={`${inputClasses} flex-1`}
-          />
-          <button onClick={() => removeBackendKey(i)} className={removeButtonClasses}>
-            ✕
-          </button>
-        </div>
-      ))}
-      <button onClick={addBackendKey} className={addButtonClasses}>
-        + Add config key
-      </button>
+      <div className="text-xs opacity-60 mb-4">
+        Terraform state is managed by Lace Cloud. The HTTP backend is configured automatically
+        during generation.
+      </div>
 
       {/* Inline save */}
       <button className={saveButtonClasses} onClick={handleSave}>

--- a/src/webview/components/panels/TerraformConfigPanel.tsx
+++ b/src/webview/components/panels/TerraformConfigPanel.tsx
@@ -4,6 +4,9 @@ import type { SettingsConfig } from '../../types/render';
 import {
   inputClasses,
   saveButtonClasses,
+  saveButtonSavingClasses,
+  saveButtonSuccessClasses,
+  saveButtonErrorClasses,
   removeButtonClasses,
   addButtonClasses,
 } from '../../styles/panel';
@@ -17,9 +20,11 @@ type ProviderRequirementRow = { name: string; source: string; version: string };
 
 // ── Content-only component (used by UnifiedSettingsPanel) ──
 
+type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
+
 type ContentProps = {
   terraform: TerraformConfig | undefined;
-  onSave: (terraform: TerraformConfig) => void;
+  onSave: (terraform: TerraformConfig) => void | Promise<void>;
 };
 
 export function TerraformConfigContent({ terraform, onSave }: ContentProps) {
@@ -52,7 +57,9 @@ export function TerraformConfigContent({ terraform, onSave }: ContentProps) {
 
   // ── Save ──
 
-  const handleSave = () => {
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
+
+  const handleSave = async () => {
     const block: TerraformConfig = {
       required_version: requiredVersion.trim() || '',
       required_providers: providers
@@ -64,7 +71,15 @@ export function TerraformConfigContent({ terraform, onSave }: ContentProps) {
         })),
     };
 
-    onSave(block);
+    setSaveStatus('saving');
+    try {
+      await onSave(block);
+      setSaveStatus('saved');
+      setTimeout(() => setSaveStatus('idle'), 1500);
+    } catch {
+      setSaveStatus('error');
+      setTimeout(() => setSaveStatus('idle'), 2000);
+    }
   };
 
   return (
@@ -119,8 +134,26 @@ export function TerraformConfigContent({ terraform, onSave }: ContentProps) {
       </div>
 
       {/* Inline save */}
-      <button className={saveButtonClasses} onClick={handleSave}>
-        Save configuration
+      <button
+        className={
+          saveStatus === 'saving'
+            ? saveButtonSavingClasses
+            : saveStatus === 'saved'
+              ? saveButtonSuccessClasses
+              : saveStatus === 'error'
+                ? saveButtonErrorClasses
+                : saveButtonClasses
+        }
+        onClick={handleSave}
+        disabled={saveStatus === 'saving'}
+      >
+        {saveStatus === 'saving'
+          ? 'Saving...'
+          : saveStatus === 'saved'
+            ? 'Saved!'
+            : saveStatus === 'error'
+              ? 'Save failed — try again'
+              : 'Save configuration'}
       </button>
     </>
   );
@@ -130,7 +163,7 @@ export function TerraformConfigContent({ terraform, onSave }: ContentProps) {
 
 type Props = {
   terraform: TerraformConfig | undefined;
-  onSave: (terraform: TerraformConfig) => void;
+  onSave: (terraform: TerraformConfig) => void | Promise<void>;
   onClose: () => void;
 };
 

--- a/src/webview/components/panels/UnifiedSettingsPanel.tsx
+++ b/src/webview/components/panels/UnifiedSettingsPanel.tsx
@@ -56,7 +56,6 @@ export default function UnifiedSettingsPanel({ engine, onClose, onSaved }: Props
                     version: p.version,
                   }))
                 : undefined,
-              terraform.backend,
             );
             onSaved?.();
           }}
@@ -106,9 +105,8 @@ export default function UnifiedSettingsPanel({ engine, onClose, onSaved }: Props
       <AccordionSection title="Environments">
         <EnvironmentsContent
           environments={settings.environments}
-          environment_backends={settings.environment_backends}
-          onSave={async (environments, backends) => {
-            await engine.setEnvironments(environments, backends);
+          onSave={async (environments) => {
+            await engine.setEnvironments(environments);
             onSaved?.();
           }}
         />

--- a/src/webview/engine.ts
+++ b/src/webview/engine.ts
@@ -112,18 +112,11 @@ export interface CanvasEngine {
   syncLayout(positions: Record<string, { x: number; y: number }>): Promise<void>;
   setVariables(variables: VariableDef[]): Promise<CanvasView>;
   setExports(outputs: OutputExportDef[], outputDefs: OutputDefEntry[]): Promise<CanvasView>;
-  setTerraform(
-    requiredVersion?: string,
-    requiredProviders?: ProviderDef[],
-    backend?: { type: string; config: Record<string, unknown> },
-  ): Promise<void>;
+  setTerraform(requiredVersion?: string, requiredProviders?: ProviderDef[]): Promise<void>;
   setProviders(providers: ProviderConfigDef[]): Promise<void>;
   setLocals(locals: LocalDef[]): Promise<CanvasView>;
   setDependsOn(instanceId: string, dependsOn: string[]): Promise<void>;
-  setEnvironments(
-    environments: Record<string, Record<string, unknown>>,
-    environmentBackends: Record<string, { type: string; config: Record<string, unknown> }>,
-  ): Promise<void>;
+  setEnvironments(environments: Record<string, Record<string, unknown>>): Promise<void>;
   undo(): Promise<CanvasView>;
   redo(): Promise<CanvasView>;
 

--- a/src/webview/getWebviewContent.ts
+++ b/src/webview/getWebviewContent.ts
@@ -52,7 +52,12 @@ export function getWebviewContent(
 
   <script nonce="${nonce}">
   window.addEventListener('DOMContentLoaded', () => {
-    // ── Cmd+S / Ctrl+S keyboard shortcut ──
+    function isTextInput(el) {
+      if (!el) return false;
+      const tag = el.tagName;
+      return tag === 'INPUT' || tag === 'TEXTAREA' || el.isContentEditable;
+    }
+    // ── Keyboard shortcuts ──
     document.addEventListener('keydown', (e) => {
       if ((e.metaKey || e.ctrlKey) && e.key === 's') {
         e.preventDefault();
@@ -62,6 +67,8 @@ export function getWebviewContent(
         e.preventDefault();
         if (window.__canvasUndo) window.__canvasUndo();
       }
+      // Copy/cut/paste: only intercept when focus is NOT on a text input
+      if (isTextInput(document.activeElement)) return;
       if ((e.metaKey || e.ctrlKey) && e.key === 'c') {
         e.preventDefault();
         if (window.__canvasCopy) window.__canvasCopy();

--- a/src/webview/post-message-engine.ts
+++ b/src/webview/post-message-engine.ts
@@ -180,15 +180,10 @@ export class PostMessageEngine implements CanvasEngine {
     return this.call('action/set_exports', { outputs, output_defs: outputDefs });
   }
 
-  setTerraform(
-    requiredVersion?: string,
-    requiredProviders?: ProviderDef[],
-    backend?: { type: string; config: Record<string, unknown> },
-  ): Promise<void> {
+  setTerraform(requiredVersion?: string, requiredProviders?: ProviderDef[]): Promise<void> {
     return this.call('action/set_terraform', {
       required_version: requiredVersion,
       required_providers: requiredProviders,
-      backend,
     });
   }
 
@@ -204,13 +199,9 @@ export class PostMessageEngine implements CanvasEngine {
     return this.call('action/set_depends_on', { instance_id: instanceId, depends_on: dependsOn });
   }
 
-  setEnvironments(
-    environments: Record<string, Record<string, unknown>>,
-    environmentBackends: Record<string, { type: string; config: Record<string, unknown> }>,
-  ): Promise<void> {
+  setEnvironments(environments: Record<string, Record<string, unknown>>): Promise<void> {
     return this.call('action/set_environments', {
       environments,
-      environment_backends: environmentBackends,
     });
   }
 

--- a/src/webview/styles/panel.ts
+++ b/src/webview/styles/panel.ts
@@ -17,6 +17,15 @@ export const rowCardClasses = 'mb-4 p-3 bg-[#0f0f0f] border border-[#333] rounde
 export const saveButtonClasses =
   'w-full py-2.5 bg-[#1f6feb] text-white border-none rounded-[10px] font-bold text-sm cursor-pointer mt-2';
 
+export const saveButtonSavingClasses =
+  'w-full py-2.5 bg-[#1a4d8f] text-white/70 border-none rounded-[10px] font-bold text-sm cursor-not-allowed mt-2';
+
+export const saveButtonSuccessClasses =
+  'w-full py-2.5 bg-[#1a7f37] text-white border-none rounded-[10px] font-bold text-sm cursor-default mt-2';
+
+export const saveButtonErrorClasses =
+  'w-full py-2.5 bg-[#6e2b2b] text-[#f87171] border-none rounded-[10px] font-bold text-sm cursor-pointer mt-2';
+
 export const footerSaveButtonClasses =
   'w-full py-3 bg-[#1f6feb] text-white border-none rounded-[10px] font-bold text-sm cursor-pointer';
 

--- a/src/webview/styles/panel.ts
+++ b/src/webview/styles/panel.ts
@@ -31,5 +31,3 @@ export const addButtonClasses =
 
 export const addButtonSmClasses =
   'text-[10px] text-[#1f6feb] cursor-pointer bg-transparent border-none mt-1';
-
-export const BACKEND_TYPES = ['s3', 'gcs', 'azurerm', 'local', 'remote'];

--- a/src/webview/types/render.ts
+++ b/src/webview/types/render.ts
@@ -71,12 +71,10 @@ export type SettingsConfig = {
   terraform: {
     required_version: string;
     required_providers: Array<{ name: string; source: string; version: string }>;
-    backend?: { type: string; config: Record<string, unknown> };
   };
   providers: Array<{ name: string; alias: string; config: Record<string, unknown> }>;
   locals: Array<{ name: string; mode: string; value_display: string }>;
   environments: Record<string, Record<string, unknown>>;
-  environment_backends: Record<string, { type: string; config: Record<string, unknown> }>;
 };
 
 export type RenderError = {


### PR DESCRIPTION
Backend type selection (S3/GCS/azurerm/local/remote) is removed from the Terraform config and environments panels. Terraform state is now exclusively managed by Lace Cloud via HTTP backend, configured automatically during generation. The proto fields are preserved for backwards compatibility but always sent as empty/undefined.