### PR TITLE
feat(ui): scaffold @lace/ui primitives foundation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,10 +18,17 @@ packages/
   host/           @lace/host           — extension host: LaceTransport (gRPC-JS), canvas/registry/chat view providers, engine lifecycle
   canvas/         @lace/canvas         — webview UI (React, ReactFlow). PostMessageEngine (VS Code) + ConnectWebEngine (browser)
   chat-sidebar/   @lace/chat-sidebar   — chat webview + host controller (agentic tool loop, tools, proactivity)
-  design-tokens/  @lace/design-tokens  — CSS variables / tokens
-  canvas-stories/ @lace/canvas-stories — Storybook for canvas (component + flow stories)
+  design-tokens/  @lace/design-tokens  — CSS variables / tokens — single source of truth for colors
+  ui/             @lace/ui             — design-system primitives (Button, IconButton, …). Composites consume these instead of re-inventing them.
+  canvas-stories/ @lace/canvas-stories — Storybook for canvas composites + @lace/ui primitives (component + flow stories)
   host-e2e/       @lace/host-e2e       — E2E scaffold (Phase G)
 ```
+
+### Design system
+
+- **Tokens first.** All colors go through `var(--lace-*)` from `@lace/design-tokens/tokens.css`. No raw hex in new code; no inline Tailwind arbitrary-value classes like `bg-[#1f6feb]`. If a color isn't in the tokens file, add a token there first.
+- **Primitives in `@lace/ui`.** `Button`, `IconButton` today; more coming (Badge, Panel, Modal, ModeToggle, CollapseToggle, Input). Stories live colocated with the primitive (`packages/ui/src/Button/Button.stories.tsx`) and are picked up by Storybook via the `canvas-stories/.storybook/main.ts` glob.
+- **Composites consume primitives.** Canvas components should import `Button` from `@lace/ui`, not reinvent button markup. Composite refactors happen incrementally — one composite per session/PR.
 
 Rspack builds three bundles from the workspace:
 

--- a/packages/canvas-stories/.storybook/main.ts
+++ b/packages/canvas-stories/.storybook/main.ts
@@ -6,7 +6,12 @@ import type { StorybookConfig } from 'storybook-react-rsbuild';
 const here = path.dirname(fileURLToPath(import.meta.url));
 
 const config: StorybookConfig = {
-  stories: ['../src/**/*.stories.@(ts|tsx)'],
+  stories: [
+    // Canvas-stories' own stories (component + flow stories for @lace/canvas).
+    '../src/**/*.stories.@(ts|tsx)',
+    // Primitive stories live colocated with the primitive under @lace/ui.
+    '../../ui/src/**/*.stories.@(ts|tsx)',
+  ],
   framework: 'storybook-react-rsbuild',
   typescript: {
     check: false,
@@ -30,6 +35,7 @@ const config: StorybookConfig = {
         '@lace/canvas': path.resolve(here, '../../canvas/src'),
         '@lace/proto': path.resolve(here, '../../proto/src'),
         '@lace/design-tokens': path.resolve(here, '../../design-tokens'),
+        '@lace/ui': path.resolve(here, '../../ui/src'),
       },
     },
   }),

--- a/packages/canvas-stories/package.json
+++ b/packages/canvas-stories/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@lace/canvas": "workspace:*",
     "@lace/design-tokens": "workspace:*",
+    "@lace/ui": "workspace:*",
     "@xyflow/react": "^12.10.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/packages/canvas/src/components/SaveButton.tsx
+++ b/packages/canvas/src/components/SaveButton.tsx
@@ -1,10 +1,5 @@
+import { Button, type ButtonVariant } from '@lace/ui';
 import type { SaveStatus } from '../hooks/useSaveState';
-import {
-  saveButtonClasses,
-  saveButtonErrorClasses,
-  saveButtonSavingClasses,
-  saveButtonSuccessClasses,
-} from '../styles/panel';
 
 type Props = {
   status: SaveStatus;
@@ -14,30 +9,35 @@ type Props = {
   disabledTitle?: string;
 };
 
-const classMap: Record<SaveStatus, string> = {
-  idle: saveButtonClasses,
-  saving: saveButtonSavingClasses,
-  saved: saveButtonSuccessClasses,
-  error: saveButtonErrorClasses,
+// Status → UI-primitive mapping. `idle` uses the caller-supplied label; the
+// other statuses carry their own user-facing text since the status itself
+// is the message (saving, saved, error). `saving` is represented by loading
+// state on the primary Button so the spinner renders consistently with any
+// other loading button in the app.
+const variantByStatus: Record<SaveStatus, ButtonVariant> = {
+  idle: 'primary',
+  saving: 'primary',
+  saved: 'success',
+  error: 'danger',
 };
 
-const textMap: Record<SaveStatus, string> = {
-  saving: 'Saving...',
+const labelByStatus: Record<Exclude<SaveStatus, 'idle'>, string> = {
+  saving: 'Saving…',
   saved: 'Saved!',
-  error: 'Save failed \u2014 try again',
-  idle: '', // overridden by label prop
+  error: 'Save failed — try again',
 };
 
 export default function SaveButton({ status, label, onClick, disabled, disabledTitle }: Props) {
   return (
-    <button
-      className={classMap[status]}
+    <Button
+      variant={variantByStatus[status]}
+      fullWidth
+      loading={status === 'saving'}
+      disabled={disabled || status === 'saved'}
       onClick={onClick}
-      disabled={disabled || status === 'saving'}
       title={disabled ? disabledTitle : undefined}
-      style={disabled ? { opacity: 0.5, cursor: 'not-allowed' } : undefined}
     >
-      {status === 'idle' ? label : textMap[status]}
-    </button>
+      {status === 'idle' ? label : labelByStatus[status]}
+    </Button>
   );
 }

--- a/packages/canvas/src/styles/panel.ts
+++ b/packages/canvas/src/styles/panel.ts
@@ -14,17 +14,11 @@ export const modeButtonInactive =
 
 export const rowCardClasses = 'mb-4 p-3 bg-[#0f0f0f] border border-[#333] rounded-lg';
 
-export const saveButtonClasses =
-  'w-full py-2.5 bg-[#1f6feb] text-white border-none rounded-[10px] font-bold text-sm cursor-pointer mt-2';
-
-export const saveButtonSavingClasses =
-  'w-full py-2.5 bg-[#1a4d8f] text-white/70 border-none rounded-[10px] font-bold text-sm cursor-not-allowed mt-2';
-
-export const saveButtonSuccessClasses =
-  'w-full py-2.5 bg-[#1a7f37] text-white border-none rounded-[10px] font-bold text-sm cursor-default mt-2';
-
-export const saveButtonErrorClasses =
-  'w-full py-2.5 bg-[#6e2b2b] text-[#f87171] border-none rounded-[10px] font-bold text-sm cursor-pointer mt-2';
+// NOTE: The old `saveButtonClasses` / `saveButtonSavingClasses` /
+// `saveButtonSuccessClasses` / `saveButtonErrorClasses` exports were
+// removed — `SaveButton` now consumes the `Button` primitive from
+// `@lace/ui`. When we refactor `ModuleConfigPanel`'s footer in a later
+// session, `footerSaveButtonClasses` goes too.
 
 export const footerSaveButtonClasses =
   'w-full py-3 bg-[#1f6feb] text-white border-none rounded-[10px] font-bold text-sm cursor-pointer';

--- a/packages/design-tokens/tokens.css
+++ b/packages/design-tokens/tokens.css
@@ -5,6 +5,11 @@
  *
  * These map to Tailwind's @theme directive in consuming packages,
  * or can be used directly as var(--lace-*).
+ *
+ * Rule for new code: canvas + chat-sidebar + @lace/ui components
+ * must reference colors through var(--lace-*). No raw hex literals,
+ * no inline Tailwind arbitrary-value classes like bg-[#1f6feb].
+ * If a color isn't in this file, add a token here first.
  */
 
 :root {
@@ -20,15 +25,27 @@
   /* ── UI: Interactive ── */
   --lace-btn-primary: #1f6feb;
   --lace-btn-primary-dim: #1a4d8f;
+  --lace-btn-secondary-bg: #2d2d2d;
+  --lace-btn-secondary-hover: #3a3a3a;
   --lace-btn-success: #1a7f37;
   --lace-btn-success-hover: #3ab653;
   --lace-btn-danger-bg: #6e2b2b;
+  --lace-btn-danger-hover: #8a3535;
+  --lace-btn-ghost-hover: rgba(206, 254, 101, 0.1);
+  --lace-btn-text-primary: #ffffff;
+  --lace-btn-text-disabled: rgba(255, 255, 255, 0.4);
+  --lace-icon-btn-hover: rgba(206, 254, 101, 0.1);
+  --lace-icon-btn-danger-hover: rgba(229, 72, 77, 0.15);
+  --lace-icon-btn-success-hover: rgba(46, 160, 67, 0.15);
   --lace-text-danger: #e5484d;
   --lace-text-danger-light: #f87171;
   --lace-text-link: #1f6feb;
   --lace-text-muted: #999999;
   --lace-text-label: #e6e6e6;
   --lace-text-description: #9ca3af;
+
+  /* ── Modal / Overlay ── */
+  --lace-modal-backdrop: rgba(0, 0, 0, 0.6);
 
   /* ── Surface ── */
   --lace-bg-surface: #1e1e1e;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@lace/canvas",
+  "name": "@lace/ui",
   "version": "0.0.0",
   "private": true,
   "main": "src/index.ts",
@@ -9,11 +9,11 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@lace/proto": "workspace:*",
-    "@lace/ui": "workspace:*",
-    "@bufbuild/protobuf": "^2.10.2"
+    "@lace/design-tokens": "workspace:*",
+    "react": "^18.3.1"
   },
   "devDependencies": {
+    "@types/react": "^18.3.12",
     "typescript": "^5.6.3"
   }
 }

--- a/packages/ui/src/Button/Button.css
+++ b/packages/ui/src/Button/Button.css
@@ -1,0 +1,145 @@
+/* Button primitive — all colors come from @lace/design-tokens CSS vars.
+ * Consumers import this via the component (import './Button.css'). */
+
+.lace-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  font-family: inherit;
+  font-weight: 500;
+  line-height: 1.2;
+  cursor: pointer;
+  transition:
+    background 120ms ease,
+    border-color 120ms ease,
+    color 120ms ease;
+  white-space: nowrap;
+  user-select: none;
+}
+
+.lace-btn:focus-visible {
+  outline: 2px solid var(--lace-green);
+  outline-offset: 2px;
+}
+
+.lace-btn--full-width {
+  width: 100%;
+}
+
+.lace-btn:disabled {
+  cursor: not-allowed;
+  color: var(--lace-btn-text-disabled);
+  opacity: 0.7;
+}
+
+/* ── Sizes ── */
+.lace-btn--size-sm {
+  padding: 4px 10px;
+  font-size: 11px;
+}
+
+.lace-btn--size-md {
+  padding: 6px 14px;
+  font-size: 12px;
+}
+
+.lace-btn--size-lg {
+  padding: 8px 18px;
+  font-size: 14px;
+}
+
+/* ── Variant: primary ── */
+.lace-btn--primary {
+  background: var(--lace-btn-primary);
+  color: var(--lace-btn-text-primary);
+}
+
+.lace-btn--primary:hover:not(:disabled) {
+  background: var(--lace-btn-primary-dim);
+}
+
+.lace-btn--primary:active:not(:disabled) {
+  background: var(--lace-btn-primary-dim);
+  transform: translateY(1px);
+}
+
+.lace-btn--primary:disabled {
+  background: var(--lace-btn-primary-dim);
+}
+
+/* ── Variant: secondary ── */
+.lace-btn--secondary {
+  background: var(--lace-btn-secondary-bg);
+  color: var(--lace-text-label);
+  border-color: var(--lace-border-default);
+}
+
+.lace-btn--secondary:hover:not(:disabled) {
+  background: var(--lace-btn-secondary-hover);
+}
+
+.lace-btn--secondary:disabled {
+  background: var(--lace-btn-secondary-bg);
+}
+
+/* ── Variant: success ── */
+.lace-btn--success {
+  background: var(--lace-btn-success);
+  color: var(--lace-btn-text-primary);
+}
+
+.lace-btn--success:hover:not(:disabled) {
+  background: var(--lace-btn-success-hover);
+}
+
+.lace-btn--success:disabled {
+  background: var(--lace-btn-success);
+}
+
+/* ── Variant: danger ── */
+.lace-btn--danger {
+  background: var(--lace-btn-danger-bg);
+  color: var(--lace-text-danger-light);
+}
+
+.lace-btn--danger:hover:not(:disabled) {
+  background: var(--lace-btn-danger-hover);
+}
+
+.lace-btn--danger:disabled {
+  background: var(--lace-btn-danger-bg);
+}
+
+/* ── Variant: ghost ── */
+.lace-btn--ghost {
+  background: transparent;
+  color: var(--lace-text-label);
+}
+
+.lace-btn--ghost:hover:not(:disabled) {
+  background: var(--lace-btn-ghost-hover);
+}
+
+/* ── Loading state ── */
+.lace-btn--loading .lace-btn__label {
+  opacity: 0.6;
+}
+
+.lace-btn__spinner {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border: 1.5px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: lace-btn-spin 600ms linear infinite;
+}
+
+@keyframes lace-btn-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/packages/ui/src/Button/Button.stories.tsx
+++ b/packages/ui/src/Button/Button.stories.tsx
@@ -1,0 +1,116 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from './Button';
+
+const meta: Meta<typeof Button> = {
+  title: 'UI / Button',
+  component: Button,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Primary labelled-button primitive. Variants: primary (default CTA), secondary (neutral), success, danger, ghost. Sizes: sm, md, lg. Supports disabled + loading states.',
+      },
+    },
+  },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['primary', 'secondary', 'success', 'danger', 'ghost'],
+    },
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+    disabled: { control: 'boolean' },
+    loading: { control: 'boolean' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Button>;
+
+export const Primary: Story = {
+  args: { children: 'Save changes', variant: 'primary' },
+};
+
+export const Secondary: Story = {
+  args: { children: 'Cancel', variant: 'secondary' },
+};
+
+export const Success: Story = {
+  args: { children: 'Saved ✓', variant: 'success' },
+};
+
+export const Danger: Story = {
+  args: { children: 'Delete module', variant: 'danger' },
+};
+
+export const Ghost: Story = {
+  args: { children: 'Dismiss', variant: 'ghost' },
+};
+
+export const Disabled: Story = {
+  args: { children: 'Save changes', variant: 'primary', disabled: true },
+};
+
+export const Loading: Story = {
+  args: { children: 'Saving…', variant: 'primary', loading: true },
+};
+
+// Layout story — all variants side-by-side at md size, for quick pixel-regression
+// capture. Chromatic diffs against this image catch cross-variant changes in
+// spacing, border-radius, font metrics, etc. without chasing per-variant screens.
+export const AllVariants: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
+      <Button variant="primary">Primary</Button>
+      <Button variant="secondary">Secondary</Button>
+      <Button variant="success">Success</Button>
+      <Button variant="danger">Danger</Button>
+      <Button variant="ghost">Ghost</Button>
+    </div>
+  ),
+};
+
+export const AllSizes: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
+      <Button size="sm">Small</Button>
+      <Button size="md">Medium</Button>
+      <Button size="lg">Large</Button>
+    </div>
+  ),
+};
+
+export const StateMatrix: Story = {
+  render: () => (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'auto 1fr 1fr 1fr',
+        gap: 12,
+        alignItems: 'center',
+      }}
+    >
+      <div />
+      <div style={{ color: '#999', fontSize: 11 }}>Idle</div>
+      <div style={{ color: '#999', fontSize: 11 }}>Disabled</div>
+      <div style={{ color: '#999', fontSize: 11 }}>Loading</div>
+      {(['primary', 'secondary', 'success', 'danger'] as const).flatMap((variant) => [
+        <div
+          key={`${variant}-label`}
+          style={{ color: '#999', fontSize: 11, textTransform: 'capitalize' }}
+        >
+          {variant}
+        </div>,
+        <Button key={`${variant}-idle`} variant={variant}>
+          Label
+        </Button>,
+        <Button key={`${variant}-disabled`} variant={variant} disabled>
+          Label
+        </Button>,
+        <Button key={`${variant}-loading`} variant={variant} loading>
+          Label
+        </Button>,
+      ])}
+    </div>
+  ),
+};

--- a/packages/ui/src/Button/Button.tsx
+++ b/packages/ui/src/Button/Button.tsx
@@ -1,0 +1,57 @@
+import type { MouseEvent, ReactNode } from 'react';
+import './Button.css';
+
+export type ButtonVariant = 'primary' | 'secondary' | 'success' | 'danger' | 'ghost';
+export type ButtonSize = 'sm' | 'md' | 'lg';
+
+export interface ButtonProps {
+  children: ReactNode;
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  /** Stretches the button to its container's width. Used by panel CTAs. */
+  fullWidth?: boolean;
+  disabled?: boolean;
+  loading?: boolean;
+  onClick?: (e: MouseEvent<HTMLButtonElement>) => void;
+  type?: 'button' | 'submit' | 'reset';
+  title?: string;
+  'aria-label'?: string;
+}
+
+export function Button({
+  children,
+  variant = 'primary',
+  size = 'md',
+  fullWidth = false,
+  disabled = false,
+  loading = false,
+  onClick,
+  type = 'button',
+  title,
+  'aria-label': ariaLabel,
+}: ButtonProps) {
+  const classes = [
+    'lace-btn',
+    `lace-btn--${variant}`,
+    `lace-btn--size-${size}`,
+    fullWidth ? 'lace-btn--full-width' : '',
+    loading ? 'lace-btn--loading' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <button
+      type={type}
+      className={classes}
+      disabled={disabled || loading}
+      onClick={onClick}
+      title={title}
+      aria-label={ariaLabel}
+      aria-busy={loading || undefined}
+    >
+      {loading ? <span className="lace-btn__spinner" aria-hidden="true" /> : null}
+      <span className="lace-btn__label">{children}</span>
+    </button>
+  );
+}

--- a/packages/ui/src/Button/index.ts
+++ b/packages/ui/src/Button/index.ts
@@ -1,0 +1,2 @@
+export type { ButtonProps, ButtonSize, ButtonVariant } from './Button';
+export { Button } from './Button';

--- a/packages/ui/src/IconButton/IconButton.css
+++ b/packages/ui/src/IconButton/IconButton.css
@@ -1,0 +1,86 @@
+/* IconButton primitive — icon-only button. All colors via @lace/design-tokens. */
+
+.lace-icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  color: var(--lace-text-label);
+  transition:
+    background 120ms ease,
+    border-color 120ms ease,
+    color 120ms ease;
+  padding: 0;
+}
+
+.lace-icon-btn:focus-visible {
+  outline: 2px solid var(--lace-green);
+  outline-offset: 2px;
+}
+
+.lace-icon-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+.lace-icon-btn__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
+/* ── Sizes ── */
+.lace-icon-btn--size-xs {
+  width: 14px;
+  height: 14px;
+}
+
+.lace-icon-btn--size-xs .lace-icon-btn__icon {
+  font-size: 10px;
+  line-height: 1;
+}
+
+.lace-icon-btn--size-sm {
+  width: 22px;
+  height: 22px;
+}
+
+.lace-icon-btn--size-sm .lace-icon-btn__icon {
+  font-size: 14px;
+  line-height: 1;
+}
+
+.lace-icon-btn--size-md {
+  width: 28px;
+  height: 28px;
+}
+
+.lace-icon-btn--size-md .lace-icon-btn__icon {
+  font-size: 16px;
+  line-height: 1;
+}
+
+/* ── Variants ── */
+.lace-icon-btn--default:hover:not(:disabled) {
+  background: var(--lace-icon-btn-hover);
+}
+
+.lace-icon-btn--danger {
+  color: var(--lace-text-danger-light);
+}
+
+.lace-icon-btn--danger:hover:not(:disabled) {
+  background: var(--lace-icon-btn-danger-hover);
+}
+
+.lace-icon-btn--success {
+  color: var(--lace-btn-success-hover);
+}
+
+.lace-icon-btn--success:hover:not(:disabled) {
+  background: var(--lace-icon-btn-success-hover);
+}

--- a/packages/ui/src/IconButton/IconButton.stories.tsx
+++ b/packages/ui/src/IconButton/IconButton.stories.tsx
@@ -1,0 +1,102 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { IconButton } from './IconButton';
+
+const meta: Meta<typeof IconButton> = {
+  title: 'UI / IconButton',
+  component: IconButton,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Icon-only button primitive. 14/22/28 px square (xs/sm/md). Variants: default (neutral), danger (red), success (green). `aria-label` is required.',
+      },
+    },
+  },
+  argTypes: {
+    variant: { control: 'select', options: ['default', 'danger', 'success'] },
+    size: { control: 'select', options: ['xs', 'sm', 'md'] },
+    disabled: { control: 'boolean' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof IconButton>;
+
+// Emoji works as a ReactNode for story purposes; real consumers will pass SVGs.
+const XIcon = '✕';
+const CheckIcon = '✓';
+const TrashIcon = '🗑';
+
+export const Default: Story = {
+  args: { icon: XIcon, 'aria-label': 'Close', variant: 'default' },
+};
+
+export const Danger: Story = {
+  args: { icon: TrashIcon, 'aria-label': 'Delete', variant: 'danger' },
+};
+
+export const Success: Story = {
+  args: { icon: CheckIcon, 'aria-label': 'Accept', variant: 'success' },
+};
+
+export const Disabled: Story = {
+  args: { icon: XIcon, 'aria-label': 'Close', disabled: true },
+};
+
+export const AllSizes: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
+      <IconButton icon={XIcon} aria-label="Close xs" size="xs" />
+      <IconButton icon={XIcon} aria-label="Close sm" size="sm" />
+      <IconButton icon={XIcon} aria-label="Close md" size="md" />
+    </div>
+  ),
+};
+
+export const VariantMatrix: Story = {
+  render: () => (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'auto 1fr 1fr 1fr',
+        gap: 12,
+        alignItems: 'center',
+      }}
+    >
+      <div />
+      <div style={{ color: '#999', fontSize: 11 }}>xs</div>
+      <div style={{ color: '#999', fontSize: 11 }}>sm</div>
+      <div style={{ color: '#999', fontSize: 11 }}>md</div>
+      {(['default', 'danger', 'success'] as const).flatMap((variant) => [
+        <div
+          key={`${variant}-label`}
+          style={{ color: '#999', fontSize: 11, textTransform: 'capitalize' }}
+        >
+          {variant}
+        </div>,
+        <IconButton
+          key={`${variant}-xs`}
+          icon={XIcon}
+          aria-label={`${variant} xs`}
+          variant={variant}
+          size="xs"
+        />,
+        <IconButton
+          key={`${variant}-sm`}
+          icon={XIcon}
+          aria-label={`${variant} sm`}
+          variant={variant}
+          size="sm"
+        />,
+        <IconButton
+          key={`${variant}-md`}
+          icon={XIcon}
+          aria-label={`${variant} md`}
+          variant={variant}
+          size="md"
+        />,
+      ])}
+    </div>
+  ),
+};

--- a/packages/ui/src/IconButton/IconButton.tsx
+++ b/packages/ui/src/IconButton/IconButton.tsx
@@ -1,0 +1,45 @@
+import type { MouseEvent, ReactNode } from 'react';
+import './IconButton.css';
+
+export type IconButtonVariant = 'default' | 'danger' | 'success';
+export type IconButtonSize = 'xs' | 'sm' | 'md';
+
+export interface IconButtonProps {
+  icon: ReactNode;
+  /** Required — icon-only buttons have no visible text label. */
+  'aria-label': string;
+  variant?: IconButtonVariant;
+  size?: IconButtonSize;
+  disabled?: boolean;
+  onClick?: (e: MouseEvent<HTMLButtonElement>) => void;
+  title?: string;
+}
+
+export function IconButton({
+  icon,
+  'aria-label': ariaLabel,
+  variant = 'default',
+  size = 'sm',
+  disabled = false,
+  onClick,
+  title,
+}: IconButtonProps) {
+  const classes = ['lace-icon-btn', `lace-icon-btn--${variant}`, `lace-icon-btn--size-${size}`]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <button
+      type="button"
+      className={classes}
+      disabled={disabled}
+      onClick={onClick}
+      title={title ?? ariaLabel}
+      aria-label={ariaLabel}
+    >
+      <span className="lace-icon-btn__icon" aria-hidden="true">
+        {icon}
+      </span>
+    </button>
+  );
+}

--- a/packages/ui/src/IconButton/index.ts
+++ b/packages/ui/src/IconButton/index.ts
@@ -1,0 +1,2 @@
+export type { IconButtonProps, IconButtonSize, IconButtonVariant } from './IconButton';
+export { IconButton } from './IconButton';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,4 @@
+export type { ButtonProps, ButtonSize, ButtonVariant } from './Button';
+export { Button } from './Button';
+export type { IconButtonProps, IconButtonSize, IconButtonVariant } from './IconButton';
+export { IconButton } from './IconButton';

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       '@lace/proto':
         specifier: workspace:*
         version: link:../proto
+      '@lace/ui':
+        specifier: workspace:*
+        version: link:../ui
     devDependencies:
       typescript:
         specifier: ^5.6.3
@@ -130,6 +133,9 @@ importers:
       '@lace/design-tokens':
         specifier: workspace:*
         version: link:../design-tokens
+      '@lace/ui':
+        specifier: workspace:*
+        version: link:../ui
       '@xyflow/react':
         specifier: ^12.10.1
         version: 12.10.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -260,6 +266,22 @@ importers:
         specifier: ^2.10.2
         version: 2.11.0
     devDependencies:
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
+  packages/ui:
+    dependencies:
+      '@lace/design-tokens':
+        specifier: workspace:*
+        version: link:../design-tokens
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+    devDependencies:
+      '@types/react':
+        specifier: ^18.3.12
+        version: 18.3.28
       typescript:
         specifier: ^5.6.3
         version: 5.9.3


### PR DESCRIPTION
## Summary

First session of the design-system rebuild. Scaffolds a new `@lace/ui`
workspace package, ships two primitives (`Button`, `IconButton`) with
full Storybook coverage, refactors `SaveButton` to consume `Button` as
proof of the pattern, and extends `@lace/design-tokens` to cover the
new primitive needs.

Visible UX doesn't change — `SaveButton` renders identically to the
old version (just swaps its internal markup for the primitive).

**Multi-session arc continues:** this is session 1 of ~7. Full roadmap
in the plan file. Future sessions add Badge/Panel/Modal primitives,
then refactor ModuleNode, GroupNode, ActionBar, etc., one composite
per PR.

## What's in this PR

### New package
- `@lace/ui` workspace package — React + design-tokens deps, plain-CSS
  approach so primitives work in any bundler.
- `Button`: `primary | secondary | success | danger | ghost` × `sm | md | lg`, plus `disabled`, `loading`, `fullWidth`.
- `IconButton`: `default | danger | success` × `xs | sm | md`. `aria-label` required.

### Design tokens extended
- New button tokens (`--lace-btn-secondary-bg`, `--lace-btn-danger-hover`, etc.)
- New icon-button hover tokens
- New `--lace-modal-backdrop` (reserved for session 2's Modal primitive)
- Header note codifies the tokens-first rule

### Storybook wiring
- `canvas-stories` picks up stories from both locations via updated glob.
- `@lace/ui` alias added.

### One composite refactored (proof)
- `SaveButton` now uses `<Button>` under the hood.
- 4 `saveButton*Classes` constants removed from `panel.ts` (they were only used by SaveButton).

### Docs
- `CLAUDE.md` has a new "Design system" section.

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `pnpm run build` — all three rspack bundles compile
- [x] `pnpm run test:unit` — 118/118 tests pass
- [x] `pnpm run storybook:build` — Storybook build succeeds with new stories
- [ ] CI (`ci.yml`) passes on PR → develop
- [ ] After merge, `ci-visual.yml` generates new Chromatic baselines for:
    - `UI / Button` (Primary, Secondary, Success, Danger, Ghost, Disabled, Loading, AllVariants, AllSizes, StateMatrix)
    - `UI / IconButton` (Default, Danger, Success, Disabled, AllSizes, VariantMatrix)
- [ ] Reviewer approves the new baselines in Chromatic UI
- [ ] `SaveButton`'s existing stories / flow tests should be pixel-near-identical (tiny font-metric / padding differences acceptable)

## Out of scope (deferred to future sessions)

- More primitives (Badge, Panel, Modal, ModeToggle, CollapseToggle, Input)
- Refactors of ModuleNode, GroupNode, ActionBar, ContextMenu, config panels
- Token-compliance sweep of the remaining canvas composites