### PR TITLE
ci: decouple Playwright flow-tests from Chromatic uploads

### DIFF
--- a/.github/workflows/ci-visual.yml
+++ b/.github/workflows/ci-visual.yml
@@ -1,11 +1,23 @@
 name: CI Visual
 
-# Heavy visual regression — Storybook + Playwright golden paths + Chromatic.
-# Runs only on push to develop (i.e., after a PR merges). Feature-branch PRs
-# get fast correctness checks via ci.yml; visual churn stays off the per-PR
-# critical path. The `visual-summary` job below is the required status check
-# on `main` — its absence on non-develop commits is what prevents PRs to main
-# from any branch other than develop.
+# Two jobs running in parallel on every push to develop:
+#
+#   flow-tests — Playwright integration + contract tests. Spawns the real
+#                lace-engine (via R2 test bundle), renders flow stories in
+#                the pinned container, asserts DOM invariants. No visual
+#                upload — catches regressions in the CLI↔extension wire
+#                format, the engine handshake, Subscribe streaming, and
+#                ReactFlow rendering against real fixture data.
+#   chromatic —  Storybook-mode Chromatic upload. Captures every component
+#                story as a visual-regression snapshot. Flow stories are
+#                `disableSnapshot: true` here (Chromatic cloud can't spawn
+#                the CLI); future sessions will add MSW-mocked flow
+#                stories so their visuals also flow through this pipeline.
+#
+# Feature-branch PRs get fast correctness checks via ci.yml; this heavier
+# suite runs only after a PR merges to develop. The `visual-summary` job
+# is the required status check on `main` — its absence on non-develop
+# commits prevents PRs to main from any branch other than develop.
 
 on:
   push:
@@ -52,28 +64,7 @@ jobs:
           # .sha256 canaries live under internal/module/server/testdata/seeds/
           # within the tarball (same path as in lace-cli).
           LACE_CLI_REPO: /tmp/lace-test
-          # takeSnapshot() from @chromatic-com/playwright captures archives
-          # under test-results/; chromatic:playwright below uploads them.
-          CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
         run: pnpm flow-tests
-
-      - name: Upload flow-test screenshots to Chromatic
-        if: always()
-        env:
-          CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-        # Workspace inside the container has a UID mismatch with the
-        # shell; git's `safe.directory` check blocks Chromatic's git log
-        # call. Whitelist the workspace before uploading.
-        #
-        # --parallel-nonce + --parallel-total merge this shard (Playwright
-        # flow-test snapshots) with the chromatic job's shard (Storybook
-        # component snapshots) into ONE Chromatic build per develop push,
-        # so reviewers see a single approval surface.
-        run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          pnpm chromatic:playwright -- \
-            --parallel-nonce=${{ github.run_id }} \
-            --parallel-total=2
 
       - name: Upload Playwright report
         if: always()
@@ -93,9 +84,20 @@ jobs:
 
   chromatic:
     # Storybook-mode Chromatic: builds the canvas-stories Storybook and
-    # uploads every component story as a visual test. Flow stories are
-    # tagged `disableSnapshot` — their visuals go through the flow-tests
-    # job above via @chromatic-com/playwright.
+    # uploads every component story as a visual test. Flow stories carry
+    # `chromatic: { disableSnapshot: true }` because Chromatic's cloud
+    # can't spawn `lace engine`. Flow-level visual regression is an
+    # explicit gap today — see the plan for adding MSW-mocked flow
+    # stories to Storybook in a later session so they flow through this
+    # same pipeline.
+    #
+    # The Playwright flow-tests job above exists for integration /
+    # contract verification (real CLI, real canvas, DOM assertions). It
+    # deliberately does not upload to Chromatic — that would create a
+    # second Chromatic build per CI run (Chromatic's Storybook-mode and
+    # Playwright-mode use different capture pipelines and produce
+    # separate build entries), and the later build would supersede and
+    # block review of the earlier one.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -113,16 +115,7 @@ jobs:
       - name: Publish to Chromatic
         env:
           CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-        # --parallel-nonce + --parallel-total merge this shard (Storybook
-        # component snapshots) with the flow-tests job's shard (Playwright
-        # snapshots) into ONE Chromatic build per develop push. Shared
-        # nonce is github.run_id — stable across the run's jobs, unique
-        # per push.
-        run: |
-          pnpm chromatic \
-            --storybook-build-dir=packages/canvas-stories/storybook-static \
-            --parallel-nonce=${{ github.run_id }} \
-            --parallel-total=2
+        run: pnpm chromatic --storybook-build-dir=packages/canvas-stories/storybook-static
 
   visual-summary:
     # Single aggregator job that main's ruleset can require. Succeeds

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,9 +62,12 @@ The repo is ruleset-gated into a three-step promotion path:
   lint + unit-tests + host-e2e + `ci-summary`. `ci-summary` is the required
   status check; direct pushes to `develop` are blocked.
 - **`develop`** is the long-lived integration branch. On every merge, a push
-  to `develop` triggers `ci-visual.yml`: builds the canvas-stories Storybook,
-  runs Playwright flow tests, uploads both sets to Chromatic as a single
-  merged build. Approve/reject in the Chromatic UI.
+  to `develop` triggers `ci-visual.yml`: in parallel, (a) the `chromatic`
+  job uploads every Storybook component story to Chromatic for visual
+  regression, and (b) the `flow-tests` job runs Playwright integration /
+  contract tests against the real `lace engine` (from the R2 test bundle)
+  with DOM assertions — no visual upload. Approve visual changes in the
+  Chromatic UI.
 - **`main`** accepts PRs only from `develop`. Two required status checks on
   the ruleset: `CI Visual / visual-summary` (only exists on commits built
   via `ci-visual.yml`, which only runs on `develop` — implicit source check)
@@ -86,29 +89,43 @@ The repo is ruleset-gated into a three-step promotion path:
 
 ### Visual regression (Chromatic)
 
-Chromatic owns visual baselines. Two modes feed the same project:
+Chromatic handles visual regression via Storybook mode only. The
+`chromatic` job in `ci-visual.yml` builds the canvas-stories Storybook
+and uploads every component story as a snapshot. New story = new
+coverage for free. CI uses `--exit-zero-on-changes` so runs stay green
+regardless of visual deltas — approval is gated in the Chromatic UI,
+not in CI.
 
-- **Storybook mode** — `ci-visual.yml`'s `chromatic` job builds the canvas-
-  stories Storybook and uploads every component story as a snapshot. New
-  story = new coverage for free.
-- **Playwright mode** — `ci-visual.yml`'s `flow-tests` job runs `tests/flow/`.
-  `takeSnapshot(page, 'name', testInfo)` from `@chromatic-com/playwright`
-  captures archives; `chromatic:playwright` uploads them.
+Flow stories carry `chromatic: { disableSnapshot: true }` because
+Chromatic's cloud can't spawn `lace engine`. Flow-level visual
+regression is a gap today, planned to be filled by adding MSW-mocked
+flow stories to Storybook in a later session (so their visuals also
+flow through Storybook mode with no live CLI dependency).
 
-Both uploads share `--parallel-nonce=${{ github.run_id }}` so Chromatic
-merges them into **one build per develop-push**. Approve/reject in
-Chromatic's UI; CI runs use `--exit-zero-on-changes` so they stay green
-regardless of visual deltas — Chromatic is the approval gate.
+### Playwright flow-tests (integration / contract)
 
-Flow stories carry `chromatic: { disableSnapshot: true }` in Storybook
-mode because Chromatic's cloud can't spawn `lace engine`. Playwright mode
-covers them.
+`tests/flow/canvas-golden-paths.spec.ts` runs the flow stories against
+a real `lace engine` in the pinned CI container, asserting shape-level
+DOM invariants (node counts, data attributes, pin counts). These are
+**integration tests, not visual tests** — no Chromatic upload.
 
-### Playwright notes
+What they catch:
+- CLI↔extension wire-format regressions (proto fields, Action oneof
+  shapes, Subscribe event types)
+- Engine handshake / auth / Subscribe stream bugs
+- ReactFlow / xyflow upgrades that break real-DOM rendering
+- Fixture-to-render drift (amplified by the seed-drift canary)
 
-- Flow stories use `testSessionOpen(fixtureName)` for determinism — stories load embedded seed fixtures from the CLI's `-tags=test` build. Requires a CLI built via `make build-test` in lace-cli.
-- The seed-drift canary (`tests/flow/seed-manifest.spec.ts`) runs first. If lace-cli regenerates seeds, the canary fails with a clear "hash mismatch" message before any visual check — update `tests/flow/__snapshots__/seed-manifest.json` in the same PR.
-- Locally, set `LACE_CLI_REPO=../lace-cli` (or absolute path) so the canary can find lace-cli's `testdata/seeds/*.sha256` canaries.
+Notes:
+- Flow stories use `testSessionOpen(fixtureName)` for determinism —
+  stories load embedded seed fixtures from the CLI's `-tags=test`
+  build. Requires a CLI built via `make build-test` in lace-cli.
+- The seed-drift canary (`tests/flow/seed-manifest.spec.ts`) runs
+  first. If lace-cli regenerates seeds, the canary fails with a clear
+  "hash mismatch" message before any flow test runs — update
+  `tests/flow/__snapshots__/seed-manifest.json` in the same PR.
+- Locally, set `LACE_CLI_REPO=../lace-cli` (or absolute path) so the
+  canary can find lace-cli's `testdata/seeds/*.sha256` canaries.
 
 ## Critical Rules
 

--- a/package.json
+++ b/package.json
@@ -164,14 +164,12 @@
     "dev:storybook-flows": "bash scripts/dev-storybook.sh",
     "flow-tests": "playwright test",
     "chromatic": "chromatic --exit-zero-on-changes",
-    "chromatic:playwright": "chromatic --playwright --exit-zero-on-changes",
     "package": "vsce package",
     "prepare": "husky",
     "release": "./scripts/release.sh"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.12",
-    "@chromatic-com/playwright": "^0.13.1",
     "@playwright/test": "1.59.1",
     "@rspack/cli": "^1.1.8",
     "@tailwindcss/postcss": "^4.1.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,9 +24,6 @@ importers:
       '@biomejs/biome':
         specifier: ^2.4.12
         version: 2.4.12
-      '@chromatic-com/playwright':
-        specifier: ^0.13.1
-        version: 0.13.1(@playwright/test@1.59.1)(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -4415,10 +4412,12 @@ snapshots:
       - react
       - react-dom
       - utf-8-validate
+    optional: true
 
   '@chromaui/rrweb-snapshot@2.0.0-alpha.18-noAbsolute':
     dependencies:
       postcss: 8.5.10
+    optional: true
 
   '@csstools/color-helpers@6.0.2': {}
 
@@ -4720,11 +4719,13 @@ snapshots:
 
   '@leichtgewicht/ip-codec@2.0.5': {}
 
-  '@lukeed/csprng@1.1.0': {}
+  '@lukeed/csprng@1.1.0':
+    optional: true
 
   '@lukeed/uuid@2.0.1':
     dependencies:
       '@lukeed/csprng': 1.1.0
+    optional: true
 
   '@module-federation/error-codes@0.22.0': {}
 
@@ -5004,10 +5005,12 @@ snapshots:
       '@segment/analytics-generic-utils': 1.2.0
       dset: 3.1.4
       tslib: 2.8.1
+    optional: true
 
   '@segment/analytics-generic-utils@1.2.0':
     dependencies:
       tslib: 2.8.1
+    optional: true
 
   '@segment/analytics-node@2.1.3':
     dependencies:
@@ -5020,6 +5023,7 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - encoding
+    optional: true
 
   '@storybook/global@5.0.0': {}
 
@@ -5658,7 +5662,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  base64-js@1.5.1: {}
+  base64-js@1.5.1:
+    optional: true
 
   baseline-browser-mapping@2.10.19: {}
 
@@ -5725,6 +5730,7 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+    optional: true
 
   bundle-name@4.1.0:
     dependencies:
@@ -6065,7 +6071,8 @@ snapshots:
     dependencies:
       detect-libc: 1.0.3
 
-  dset@3.1.4: {}
+  dset@3.1.4:
+    optional: true
 
   dunder-proto@1.0.1:
     dependencies:
@@ -6528,7 +6535,8 @@ snapshots:
     dependencies:
       postcss: 8.5.10
 
-  ieee754@1.2.1: {}
+  ieee754@1.2.1:
+    optional: true
 
   immediate@3.0.6: {}
 
@@ -6659,7 +6667,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
-  jose@5.10.0: {}
+  jose@5.10.0:
+    optional: true
 
   js-tokens@4.0.0: {}
 
@@ -7014,6 +7023,7 @@ snapshots:
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+    optional: true
 
   node-forge@1.4.0: {}
 
@@ -7691,6 +7701,7 @@ snapshots:
       - react
       - react-dom
       - utf-8-validate
+    optional: true
 
   storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -7855,7 +7866,8 @@ snapshots:
     dependencies:
       tldts: 7.0.28
 
-  tr46@0.0.3: {}
+  tr46@0.0.3:
+    optional: true
 
   tr46@6.0.0:
     dependencies:
@@ -8077,7 +8089,8 @@ snapshots:
     dependencies:
       minimalistic-assert: 1.0.1
 
-  webidl-conversions@3.0.1: {}
+  webidl-conversions@3.0.1:
+    optional: true
 
   webidl-conversions@8.0.1: {}
 
@@ -8208,6 +8221,7 @@ snapshots:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
+    optional: true
 
   which-typed-array@1.1.20:
     dependencies:

--- a/tests/flow/canvas-golden-paths.spec.ts
+++ b/tests/flow/canvas-golden-paths.spec.ts
@@ -1,27 +1,35 @@
 /**
- * Canvas golden-path tests.
+ * Canvas integration / contract tests.
  *
- * One test per flow story. Each navigates to Storybook's iframe URL for
- * the story, waits for the `[data-flow-ready]` marker the FlowDecorator
- * renders once boot completes (TestSessionOpen + Subscribe + initial
- * StateUpdated), asserts a small shape-level DOM invariant, and captures
- * a Chromatic snapshot via `takeSnapshot`.
+ * One test per flow story. Each:
+ *   1. Navigates to the Storybook iframe URL for the story
+ *   2. Waits for the `[data-flow-ready]` marker — the FlowDecorator
+ *      renders this once TestSessionOpen + Subscribe + initial
+ *      StateUpdated have completed against the real `lace engine`
+ *      (spawned in CI via the R2 test bundle)
+ *   3. Asserts shape-level DOM invariants (node counts, data attributes,
+ *      pin counts) that prove the engine → canvas pipeline is wired
+ *      correctly end-to-end
  *
- * Baselines live in Chromatic, not git. CI passes CHROMATIC_PROJECT_TOKEN
- * to the `flow-tests` job; `chromatic:playwright` uploads after the test
- * run. Visual diffs surface as PR comments from the Chromatic bot;
- * approve/reject in the Chromatic UI.
+ * These are NOT visual regression tests. Visual regression for
+ * components lives in Chromatic via Storybook mode; flow-level visual
+ * regression is a gap today (planned to be filled by adding
+ * MSW-mocked flow stories to Storybook in a later session, so those
+ * visuals flow through the same Chromatic pipeline).
  *
- * `drift-badge` is intentionally absent: lace-cli's `pb.RenderNode` has no
- * drift metadata yet. Followup once the proto extends.
+ * What this suite catches that nothing else does:
+ *   - CLI↔extension wire-format regressions (proto fields, Action
+ *     oneof shapes, Subscribe event types)
+ *   - Engine handshake / auth / Subscribe stream bugs
+ *   - ReactFlow / xyflow upgrades that break real-DOM rendering
+ *   - Fixture-to-render drift (amplified by the seed-drift canary
+ *     in tests/flow/seed-manifest.spec.ts)
+ *
+ * `drift-badge` is intentionally absent: lace-cli's `pb.RenderNode` has
+ * no drift metadata yet. Followup once the proto extends.
  */
 
-// `test` and `expect` MUST come from @chromatic-com/playwright — those
-// wrap Playwright's equivalents with hooks that capture Chromatic
-// archives under test-results/chromatic-archives/. Without the wrapped
-// test, `takeSnapshot` is a silent no-op and `chromatic:playwright`
-// fails the upload with "archives directory cannot be found."
-import { expect, takeSnapshot, test } from '@chromatic-com/playwright';
+import { expect, test } from '@playwright/test';
 
 // Shared story URL helper — Storybook serves each story in an iframe at
 // /iframe.html?id=<kebab-title>--<kebab-name>&viewMode=story.
@@ -56,27 +64,23 @@ async function gotoStory(page: import('@playwright/test').Page, storyId: string)
 }
 
 test.describe('flow story golden paths', () => {
-  test('empty-state: empty canvas, no nodes, no errors', async ({ page }, testInfo) => {
+  test('empty-state: empty canvas, no nodes, no errors', async ({ page }) => {
     await gotoStory(page, 'flows-emptycanvas--default');
     // Canvas mounts but no ReactFlow nodes render.
     const nodeCount = await page.locator('.react-flow__node').count();
     expect(nodeCount).toBe(0);
-    await takeSnapshot(page, 'empty-state', testInfo);
   });
 
-  test('drop-module: single iam-role node placed', async ({ page }, testInfo) => {
+  test('drop-module: single iam-role node placed', async ({ page }) => {
     await gotoStory(page, 'flows-iamrole--default');
     // Exactly one node from the iam-role seed.
     await expect(page.locator('.react-flow__node')).toHaveCount(1);
     // The node's label should mention "role" — coarse, but catches
     // schema-shape regressions without pinning to an exact label.
     await expect(page.locator('.react-flow__node').first()).toContainText(/role/i);
-    await takeSnapshot(page, 'drop-module', testInfo);
   });
 
-  test('composite-hierarchy: iam-stack fixture renders a collapsed composite', async ({
-    page,
-  }, testInfo) => {
+  test('composite-hierarchy: iam-stack fixture renders a collapsed composite', async ({ page }) => {
     await gotoStory(page, 'flows-iamstack--default');
     // Post composite preservation: iam-stack drops as ONE top-level
     // collapsed composite group. Its internal tree (iam_role leaf +
@@ -96,27 +100,19 @@ test.describe('flow story golden paths', () => {
     // proxy for "the Interface was carried end-to-end".
     const pinCount = await page.locator('[data-group="iam_stack"] .react-flow__handle').count();
     expect(pinCount).toBeGreaterThanOrEqual(6);
-    await takeSnapshot(page, 'composite-hierarchy', testInfo);
   });
 
-  test('collapse-group: group renders collapsed', async ({ page }, testInfo) => {
+  test('collapse-group: group renders collapsed', async ({ page }) => {
     await gotoStory(page, 'flows-collapsedgroup--default');
     // GroupNode tags its root div with `data-group` (= groupId) and
     // `data-collapsed` (= "true" | "false"). The collapsed-group fixture
     // has exactly one group in collapsed state.
     await expect(page.locator('[data-collapsed="true"]')).toHaveCount(1);
-    await takeSnapshot(page, 'collapse-group', testInfo);
   });
 
-  test('generate-flow: wired-stack fixture renders 3 pre-wired nodes', async ({
-    page,
-  }, testInfo) => {
+  test('generate-flow: wired-stack fixture renders 3 pre-wired nodes', async ({ page }) => {
     await gotoStory(page, 'flows-wiredstack--default');
     // wired-stack seed: 3 leaf bundles + 2 cross-bundle wires (per Plan 1 Phase F fixtures).
     await expect(page.locator('.react-flow__node')).toHaveCount(3);
-    // Baseline capture of the wired stack BEFORE any generate click —
-    // post-generate state has transient toasts that are harder to snapshot
-    // deterministically. Clicking generate lives in a followup interaction test.
-    await takeSnapshot(page, 'generate-flow', testInfo);
   });
 });


### PR DESCRIPTION
## Summary

Stops uploading Playwright flow-test snapshots to Chromatic. This
resolves the two-builds-per-CI-run problem that was blocking review in
the Chromatic UI. Flow-tests continue to run — their purpose is
reframed as integration / contract verification, which is what they're
actually best at.

## The problem we hit

Chromatic's Storybook mode and Playwright mode use separate capture
pipelines that cannot be merged into one Chromatic build. Each
\`ci-visual.yml\` run produced two builds on the same commit; the
later one superseded the earlier and **locked it from review**, so
primitive snapshots (Button, IconButton) couldn't be approved.

My earlier attempt to merge them via \`--parallel-nonce\` /
\`--parallel-total\` was wrong — those flags **don't exist** in
\`chromatic@16.3.0\` (verified via \`npx chromatic --help\`). They
were silently ignored.

## What this PR does

- **ci-visual.yml** — drops the \`Upload flow-test screenshots to
  Chromatic\` step from the flow-tests job. Drops the non-functional
  \`--parallel-nonce\` / \`--parallel-total\` flags from the
  chromatic (Storybook-mode) job.
- **package.json** — removes \`@chromatic-com/playwright\` devDep and
  the \`chromatic:playwright\` script.
- **canvas-golden-paths.spec.ts** — imports \`test\`/\`expect\` from
  \`@playwright/test\` again. Drops \`takeSnapshot\` calls and
  \`testInfo\` parameters. DOM assertions unchanged.
- **CLAUDE.md** — rewrites the Visual regression + Playwright sections
  to reflect the split cleanly.

## Why keep Playwright flow-tests at all?

They serve a distinct purpose nothing else covers:

- **CLI↔extension wire-format regressions** — proto fields, Action
  oneof shapes, Subscribe event types. Unit tests each mock the other
  side; only end-to-end catches contract drift.
- **Engine handshake / auth / Subscribe stream bugs** — real RPC
  over real network.
- **ReactFlow / xyflow upgrades** — happy-dom can't execute xyflow's
  measurement pass; real browser matters.
- **Fixture-to-render integration** — amplified by the seed-drift
  canary.

They're integration tests, not visual regression tests. That's what
they should have been labeled all along.

## What's the gap this leaves?

**Visual regression on flow stories is a deliberate gap.** We no
longer pixel-diff the canvas rendering of iam-stack / wired-stack /
etc. Planned to be filled in a future session by adding MSW-mocked
flow stories to Storybook so they flow through Chromatic's Storybook
mode alongside component stories — one build, one review surface,
includes both primitive + layout + integration visuals. See the plan
file for the roadmap.

## Test plan

- [x] \`npx tsc --noEmit\` — zero errors
- [x] \`pnpm run test:unit\` — 118/118 pass
- [x] YAML + JSON parse checks pass
- [ ] CI (\`ci.yml\`) green on PR → develop
- [ ] After merge, the next \`ci-visual.yml\` run on develop produces
    **one** Chromatic build (Storybook mode only, 12 components, 38
    stories — or whatever the current count is after storiesstories land).
    Reviewable; approve primitives + existing components to establish
    baselines.
- [ ] Flow-tests job still runs green (integration coverage preserved).

## Out of scope

- Adding MSW-mocked flow stories for visual regression (future session)
- Additional primitives (Badge, Panel, Modal — future sessions)
- Composite refactors (future sessions)