### PR TITLE
refactor(stories): story hygiene sweep (Session 1.5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,45 @@ regression is a gap today, planned to be filled by adding MSW-mocked
 flow stories to Storybook in a later session (so their visuals also
 flow through Storybook mode with no live CLI dependency).
 
+#### Review protocol
+
+Chromatic's diff view only shows *changed* pixels. That's not enough
+to catch a story that renders broken in isolation — a newly-broken
+story gets accepted as a clean baseline. So every PR review walks
+through the Storybook Library view, not just the diff.
+
+- **PR description lists new/changed stories.** One bullet per story
+  so the reviewer knows what to click. If a PR only touches plumbing
+  (no story changes), say that.
+- **Reviewer opens each in the Chromatic Library**, not just the
+  "Changes" tab. Confirm the component looks the way it should look
+  in the real app — not just that nothing is different from last
+  time.
+- **Broken-isolation stories → deny in Chromatic + fix forward.**
+  Never accept a snapshot of a misrendered story as the baseline.
+  Diagnose why it renders broken (missing CSS, missing positioning
+  context, missing provider, missing decorator) and fix it in the
+  same PR.
+- **Stories tagged `chromatic: { disableSnapshot: true }` are
+  ignored.** Flow stories fall here — they need a live CLI that
+  Chromatic's cloud can't spawn, so the library shows the
+  `CliMissingBanner` fallback. That's expected; not a review item.
+- **Rule of thumb:** if a story in the library doesn't match how the
+  component actually looks in the app, the story or the component is
+  wrong — never the baseline.
+
+#### Scene stories (introduced Session 4+)
+
+A **scene story** composes multiple components in their intended
+spatial arrangement — e.g. a canvas with two wired ModuleNodes + a
+ContextMenu open on the second one, all at real layout scale. Scene
+stories catch layout regressions that single-component stories miss
+(header overlapping pin rows, context menu escaping the canvas
+frame, panel pushing the canvas below the fold) and serve as
+designer-facing reference renders. They're introduced alongside
+composite refactors from Session 4 onward; earlier sessions stick to
+primitive / single-composite stories.
+
 ### Playwright flow-tests (integration / contract)
 
 `tests/flow/canvas-golden-paths.spec.ts` runs the flow stories against

--- a/packages/canvas-stories/src/stories/ContextMenu.stories.tsx
+++ b/packages/canvas-stories/src/stories/ContextMenu.stories.tsx
@@ -15,6 +15,11 @@ const meta: Meta<typeof ContextMenu> = {
           width: 600,
           height: 400,
           background: 'var(--lace-night)',
+          // `transform` creates a containing block, so the menu's
+          // `position: fixed` stays inside the decorator box instead of
+          // escaping to the viewport. Real-world positioning is unchanged —
+          // Canvas has no ancestor transform.
+          transform: 'translateZ(0)',
         }}
       >
         <Story />

--- a/packages/canvas-stories/src/stories/ModuleNode.stories.tsx
+++ b/packages/canvas-stories/src/stories/ModuleNode.stories.tsx
@@ -39,7 +39,7 @@ const meta: Meta<StoryArgs> = {
 export default meta;
 type Story = StoryObj<StoryArgs>;
 
-export const SimpleLeaf: Story = {
+export const SimpleModule: Story = {
   args: {
     data: {
       id: 'vpc',

--- a/packages/canvas-stories/src/stories/flows/IamStack.stories.tsx
+++ b/packages/canvas-stories/src/stories/flows/IamStack.stories.tsx
@@ -3,7 +3,7 @@ import { FlowDecorator } from '../../decorators/flow-decorator';
 
 // Module-tree flow: loads the CLI's `iam-stack` seed. Renders as one
 // collapsed group at the canvas root (iam_stack), containing a nested
-// tree — iam_role (leaf) + cloudwatch_logs_policy (another collapsed
+// tree — iam_role (module) + cloudwatch_logs_policy (another collapsed
 // group, which itself contains policy + attachment). Exercises the
 // collapsed-group pin rail + nested-group hiding paths.
 

--- a/packages/canvas-stories/src/stories/flows/WiredStack.stories.tsx
+++ b/packages/canvas-stories/src/stories/flows/WiredStack.stories.tsx
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { FlowDecorator } from '../../decorators/flow-decorator';
 
-// Pre-wired flow: loads the CLI's `wired-stack` seed — three leaf
-// modules (iam_role, iam_policy, iam_policy_attachment) with two
+// Pre-wired flow: loads the CLI's `wired-stack` seed — three modules
+// (iam_role, iam_policy, iam_policy_attachment) with two
 // pre-wired edges (role.role_name → attachment.role_name,
 // policy.policy_arn → attachment.policy_arn). Clicking the Generate
 // button exercises the full GenerateProgress → GenerateSuccess event

--- a/packages/canvas/src/components/ContextMenu.css
+++ b/packages/canvas/src/components/ContextMenu.css
@@ -1,0 +1,46 @@
+/* ContextMenu — right-click menu over the canvas. All colors flow through
+ * @lace/design-tokens. The pattern mirrors @lace/ui primitives: plain CSS,
+ * colocated with the component, imported from the TSX module. Keeps this
+ * composite renderable in Storybook where Tailwind v4 doesn't scan the
+ * @lace/canvas package for arbitrary-value utilities. */
+
+.lace-ctx-menu {
+  position: fixed;
+  z-index: 50;
+  min-width: 120px;
+  padding: 4px 0;
+  background: var(--lace-bg-context-menu);
+  border: 1px solid var(--lace-green-alpha-20);
+  border-radius: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+}
+
+.lace-ctx-menu__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  width: 100%;
+  padding: 6px 12px;
+  background: transparent;
+  border: none;
+  color: var(--lace-green);
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.lace-ctx-menu__item:hover {
+  background: var(--lace-gunmetal);
+}
+
+.lace-ctx-menu__shortcut {
+  color: var(--lace-text-muted);
+  font-size: 10px;
+}
+
+.lace-ctx-menu__scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+}

--- a/packages/canvas/src/components/ContextMenu.tsx
+++ b/packages/canvas/src/components/ContextMenu.tsx
@@ -1,4 +1,5 @@
 import type { ContextMenuState } from '../hooks/useContextMenu';
+import './ContextMenu.css';
 
 type Props = {
   contextMenu: ContextMenuState;
@@ -24,10 +25,8 @@ export default function ContextMenu({
   const items: { label: string; shortcut?: string; action: () => void }[] = [];
 
   if (contextMenu.groupId) {
-    // Right-clicked on a group node
     items.push({ label: 'Ungroup', action: () => onUngroup(contextMenu.groupId!) });
   } else {
-    // Standard items
     items.push(
       { label: 'Cut', shortcut: 'Ctrl+X', action: onCut },
       { label: 'Copy', shortcut: 'Ctrl+C', action: onCopy },
@@ -41,24 +40,23 @@ export default function ContextMenu({
   return (
     <>
       <div
-        className="fixed z-50 bg-[#1a1a1a] border border-[rgba(206,254,101,0.2)] rounded shadow-[0_4px_12px_rgba(0,0,0,0.5)] py-1"
-        style={{ left: contextMenu.x, top: contextMenu.y, minWidth: 120 }}
+        className="lace-ctx-menu"
+        style={{ left: contextMenu.x, top: contextMenu.y }}
         onMouseDown={(e) => e.stopPropagation()}
       >
         {items.map(({ label, shortcut, action }) => (
           <button
             key={label}
-            className="w-full text-left px-3 py-1.5 text-xs text-[#CEFE65] hover:bg-[#153238] cursor-pointer flex items-center justify-between gap-4"
-            style={{ background: 'transparent', border: 'none' }}
+            type="button"
+            className="lace-ctx-menu__item"
             onClick={() => action()}
           >
             <span>{label}</span>
-            {shortcut && <span className="text-[#5a7060] text-[10px]">{shortcut}</span>}
+            {shortcut && <span className="lace-ctx-menu__shortcut">{shortcut}</span>}
           </button>
         ))}
       </div>
-      {/* Dismiss on outside click */}
-      <div className="fixed inset-0 z-40" onClick={onDismiss} />
+      <div className="lace-ctx-menu__scrim" onClick={onDismiss} />
     </>
   );
 }

--- a/packages/canvas/src/components/Toast.css
+++ b/packages/canvas/src/components/Toast.css
@@ -1,0 +1,47 @@
+/* Toast — transient banner anchored top-left in the canvas viewport.
+ * Colors pull from @lace/design-tokens; no raw hex or Tailwind arbitrary
+ * utilities so the component renders identically in the canvas bundle
+ * and in Storybook (where Tailwind v4 doesn't scan @lace/canvas). */
+
+.lace-toast {
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  font-size: 12px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+}
+
+.lace-toast--success,
+.lace-toast--progress {
+  background: var(--lace-toast-success-bg);
+  color: var(--lace-green);
+  border-color: var(--lace-toast-success-border);
+}
+
+.lace-toast--error {
+  background: var(--lace-toast-error-bg);
+  color: var(--lace-text-danger-light);
+  border-color: var(--lace-toast-error-border);
+}
+
+.lace-toast__spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--lace-green);
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: lace-toast-spin 900ms linear infinite;
+}
+
+@keyframes lace-toast-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/packages/canvas/src/components/Toast.tsx
+++ b/packages/canvas/src/components/Toast.tsx
@@ -1,4 +1,5 @@
 import type { ToastState } from '../hooks/useToast';
+import './Toast.css';
 
 type Props = {
   toast: ToastState;
@@ -6,17 +7,11 @@ type Props = {
 
 export default function Toast({ toast }: Props) {
   if (!toast) return null;
+  const variant =
+    toast.type === 'error' ? 'error' : toast.type === 'progress' ? 'progress' : 'success';
   return (
-    <div
-      className={`absolute top-4 left-4 z-20 flex items-center gap-2 px-3 py-1.5 rounded-md text-xs shadow-[0_2px_6px_rgba(0,0,0,0.3)] border ${
-        toast.type === 'error'
-          ? 'bg-[#3a1518] text-[#f87171] border-[rgba(248,113,113,0.3)]'
-          : 'bg-[#153238] text-[#CEFE65] border-[rgba(206,254,101,0.2)]'
-      }`}
-    >
-      {toast.type === 'progress' && (
-        <div className="w-3.5 h-3.5 border-2 border-[#CEFE65] border-t-transparent rounded-full animate-spin" />
-      )}
+    <div className={`lace-toast lace-toast--${variant}`}>
+      {toast.type === 'progress' && <div className="lace-toast__spinner" aria-hidden="true" />}
       {toast.message}
     </div>
   );

--- a/packages/design-tokens/tokens.css
+++ b/packages/design-tokens/tokens.css
@@ -47,6 +47,12 @@
   /* ── Modal / Overlay ── */
   --lace-modal-backdrop: rgba(0, 0, 0, 0.6);
 
+  /* ── Toast ── */
+  --lace-toast-success-bg: #153238;
+  --lace-toast-success-border: rgba(206, 254, 101, 0.2);
+  --lace-toast-error-bg: #3a1518;
+  --lace-toast-error-border: rgba(248, 113, 113, 0.3);
+
   /* ── Surface ── */
   --lace-bg-surface: #1e1e1e;
   --lace-bg-surface-alt: #252526;


### PR DESCRIPTION
## Summary

- Convert `ContextMenu` and `Toast` to plain CSS + `@lace/design-tokens` so their Storybook stories render correctly — Tailwind v4 in the Storybook build only scans `canvas-stories`, so arbitrary-value classes in `@lace/canvas` never compiled and both composites were rendering unstyled in Chromatic's Library view.
- `ContextMenu` story decorator now creates a containing block (`transform: translateZ(0)`) so `position: fixed` stays inside the 600×400 decorator frame instead of escaping to the viewport.
- Rename `Components/ModuleNode / Simple Leaf` → `Components/ModuleNode / Simple Module`; also clean up two `leaf` mentions in flow-story prose (leaf/composite vocabulary belongs to lace-cli, not the extension).
- Document the Chromatic **review protocol** in `CLAUDE.md` (reviewer walks through the full Library view, not just the diff; broken-isolation stories → deny + fix forward) and introduce the **scene stories** concept for Session 4+.
- Add four tokens (`--lace-toast-success-bg/border`, `--lace-toast-error-bg/border`) to preserve Toast's existing color palette under the tokens-first rule.

## Stories new/changed in this PR

- **Components/ContextMenu / Single Node** — now renders the actual right-click menu (dark bg, green labels, grey shortcut hints). Previously: unstyled inline "CutCtrl+XCopyCtrl+CPasteCtrl+V" blob.
- **Components/ContextMenu / Multi Select** — same fix; adds "Group Selected" row.
- **Components/ContextMenu / Group Right Click** — same fix; renders a single "Ungroup" row.
- **Components/Toast / Success** — gunmetal bg, green text, green border. Previously: unstyled.
- **Components/Toast / Error State** — dark-red bg, red text, red border. Previously: unstyled.
- **Components/Toast / Progress Generating** — success styling plus a spinning ring. Previously: unstyled.
- **Components/Toast / Progress Formatting** — identical progress styling, different copy.
- **Components/ModuleNode / Simple Module** — renamed from `Simple Leaf`; rendering unchanged.

No other stories change visually. `UI/Button`, `UI/IconButton`, `Components/GroupNode`, `Components/SlidePanel` were verified to still render correctly locally. `Flows/*` stories stay tagged `disableSnapshot: true` (CLI required).

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `pnpm run test:unit` — 118/118 pass
- [x] `pnpm run build` — rspack green (all three bundles)
- [x] `pnpm run lint` — biome clean
- [x] Verified each broken story manually in Storybook (Playwright MCP screenshots) before + after the refactor
- [ ] Post-merge: review new ContextMenu + Toast baselines in Chromatic Library; accept if they match the application

🤖 Generated with [Claude Code](https://claude.com/claude-code)