### PR TITLE
fix(canvas): shorten ContextMenu 'Group Selected' to 'Group'

### DIFF
--- a/packages/canvas/src/components/ContextMenu.tsx
+++ b/packages/canvas/src/components/ContextMenu.tsx
@@ -33,7 +33,7 @@ export default function ContextMenu({
       { label: 'Paste', shortcut: 'Ctrl+V', action: onPaste },
     );
     if (contextMenu.selectedCount >= 2) {
-      items.push({ label: 'Group Selected', action: onGroupSelected });
+      items.push({ label: 'Group', action: onGroupSelected });
     }
   }
 


### PR DESCRIPTION
## Summary

- The Group item only appears when 2+ nodes are selected, so the 'Selected' qualifier was redundant.
- Matches the adjacent single-word items: Cut / Copy / Paste / Ungroup.

## Stories new/changed

- **Components/ContextMenu / Multi Select** — label changes from 'Group Selected' to 'Group'. Expect a small pixel diff in Chromatic (fewer characters). Single Node + Group Right Click stories unchanged.

## Test plan

- [x] \`npx tsc --noEmit\` — zero errors
- [x] \`pnpm run test:unit\` — 118/118 pass
- [ ] Post-merge: accept new Chromatic baseline for Multi Select

🤖 Generated with [Claude Code](https://claude.com/claude-code)