### PR TITLE
feat(ui): add Badge, Panel, Modal primitives (Session 2)

### DIFF
--- a/packages/design-tokens/tokens.css
+++ b/packages/design-tokens/tokens.css
@@ -46,12 +46,34 @@
 
   /* ── Modal / Overlay ── */
   --lace-modal-backdrop: rgba(0, 0, 0, 0.6);
+  --lace-modal-shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
+
+  /* ── Panel ── */
+  --lace-panel-shadow: 0 2px 12px rgba(0, 0, 0, 0.35);
 
   /* ── Toast ── */
   --lace-toast-success-bg: #153238;
   --lace-toast-success-border: rgba(206, 254, 101, 0.2);
   --lace-toast-error-bg: #3a1518;
   --lace-toast-error-border: rgba(248, 113, 113, 0.3);
+
+  /* ── Badge ── */
+  /* Neutral: quiet count/meta pills (e.g. "(5)") */
+  --lace-badge-neutral-bg: transparent;
+  --lace-badge-neutral-border: var(--lace-border-default);
+  --lace-badge-neutral-text: var(--lace-text-muted);
+  /* Info: reuse existing blue tag tokens for versions etc. */
+  --lace-badge-info-bg: var(--lace-tag-bg);
+  --lace-badge-info-border: var(--lace-tag-border);
+  --lace-badge-info-text: var(--lace-tag-text);
+  /* Success: brand green, low saturation */
+  --lace-badge-success-bg: rgba(46, 160, 67, 0.12);
+  --lace-badge-success-border: rgba(46, 160, 67, 0.35);
+  --lace-badge-success-text: var(--lace-accent-green);
+  /* Danger: red border/text on transparent, used for destructive chips */
+  --lace-badge-danger-bg: transparent;
+  --lace-badge-danger-border: var(--lace-text-danger);
+  --lace-badge-danger-text: var(--lace-text-danger);
 
   /* ── Surface ── */
   --lace-bg-surface: #1e1e1e;

--- a/packages/ui/src/Badge/Badge.css
+++ b/packages/ui/src/Badge/Badge.css
@@ -1,0 +1,52 @@
+/* Badge primitive — pill used for counts, versions, status chips.
+ * Variants reference the --lace-badge-* token family so consumers can
+ * restyle the entire badge family from one place. */
+
+.lace-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  font-family: inherit;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+/* ── Sizes ── */
+.lace-badge--size-sm {
+  padding: 2px 7px;
+  font-size: 10px;
+}
+
+.lace-badge--size-md {
+  padding: 3px 10px;
+  font-size: 11px;
+}
+
+/* ── Variants ── */
+.lace-badge--neutral {
+  background: var(--lace-badge-neutral-bg);
+  border-color: var(--lace-badge-neutral-border);
+  color: var(--lace-badge-neutral-text);
+  font-weight: 500;
+}
+
+.lace-badge--info {
+  background: var(--lace-badge-info-bg);
+  border-color: var(--lace-badge-info-border);
+  color: var(--lace-badge-info-text);
+}
+
+.lace-badge--success {
+  background: var(--lace-badge-success-bg);
+  border-color: var(--lace-badge-success-border);
+  color: var(--lace-badge-success-text);
+}
+
+.lace-badge--danger {
+  background: var(--lace-badge-danger-bg);
+  border-color: var(--lace-badge-danger-border);
+  color: var(--lace-badge-danger-text);
+}

--- a/packages/ui/src/Badge/Badge.stories.tsx
+++ b/packages/ui/src/Badge/Badge.stories.tsx
@@ -1,0 +1,85 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Badge } from './Badge';
+
+const meta: Meta<typeof Badge> = {
+  title: 'UI / Badge',
+  component: Badge,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Inline pill used for counts, version tags, and status chips. Variants: neutral (quiet count pill), info (version tag), success (ok state), danger (destructive / error state). Sizes: sm (default), md.',
+      },
+    },
+  },
+  argTypes: {
+    variant: { control: 'select', options: ['neutral', 'info', 'success', 'danger'] },
+    size: { control: 'select', options: ['sm', 'md'] },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Badge>;
+
+export const Neutral: Story = {
+  args: { children: '(5)', variant: 'neutral' },
+};
+
+export const Info: Story = {
+  args: { children: 'v1.0.0', variant: 'info' },
+};
+
+export const Success: Story = {
+  args: { children: 'Applied', variant: 'success' },
+};
+
+export const Danger: Story = {
+  args: { children: 'Remove', variant: 'danger' },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+      <Badge variant="neutral">(5)</Badge>
+      <Badge variant="info">v1.0.0</Badge>
+      <Badge variant="success">Applied</Badge>
+      <Badge variant="danger">Remove</Badge>
+    </div>
+  ),
+};
+
+export const SizeMatrix: Story = {
+  render: () => (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'auto 1fr 1fr',
+        gap: 10,
+        alignItems: 'center',
+      }}
+    >
+      <div />
+      <div style={{ color: '#999', fontSize: 11 }}>sm</div>
+      <div style={{ color: '#999', fontSize: 11 }}>md</div>
+      {(['neutral', 'info', 'success', 'danger'] as const).flatMap((variant) => [
+        <div
+          key={`${variant}-label`}
+          style={{ color: '#999', fontSize: 11, textTransform: 'capitalize' }}
+        >
+          {variant}
+        </div>,
+        <div key={`${variant}-sm`} style={{ justifySelf: 'start' }}>
+          <Badge variant={variant} size="sm">
+            label
+          </Badge>
+        </div>,
+        <div key={`${variant}-md`} style={{ justifySelf: 'start' }}>
+          <Badge variant={variant} size="md">
+            label
+          </Badge>
+        </div>,
+      ])}
+    </div>
+  ),
+};

--- a/packages/ui/src/Badge/Badge.tsx
+++ b/packages/ui/src/Badge/Badge.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react';
+import './Badge.css';
+
+export type BadgeVariant = 'neutral' | 'info' | 'success' | 'danger';
+export type BadgeSize = 'sm' | 'md';
+
+export interface BadgeProps {
+  children: ReactNode;
+  variant?: BadgeVariant;
+  size?: BadgeSize;
+  title?: string;
+}
+
+export function Badge({ children, variant = 'neutral', size = 'sm', title }: BadgeProps) {
+  const classes = `lace-badge lace-badge--${variant} lace-badge--size-${size}`;
+  return (
+    <span className={classes} title={title}>
+      {children}
+    </span>
+  );
+}

--- a/packages/ui/src/Badge/index.ts
+++ b/packages/ui/src/Badge/index.ts
@@ -1,0 +1,2 @@
+export type { BadgeProps, BadgeSize, BadgeVariant } from './Badge';
+export { Badge } from './Badge';

--- a/packages/ui/src/Modal/Modal.css
+++ b/packages/ui/src/Modal/Modal.css
@@ -1,0 +1,93 @@
+/* Modal primitive — centered dialog over a full-viewport backdrop.
+ * Backdrop click + Escape dismiss. Consumers provide the actions in
+ * the footer slot; Modal only owns the chrome. */
+
+.lace-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--lace-modal-backdrop);
+}
+
+.lace-modal {
+  display: flex;
+  flex-direction: column;
+  max-width: calc(100vw - 48px);
+  max-height: calc(100vh - 96px);
+  background: var(--lace-bg-context-menu);
+  border: 1px solid var(--lace-border-default);
+  border-radius: 8px;
+  box-shadow: var(--lace-modal-shadow);
+  color: var(--lace-grey);
+  font-family: inherit;
+  overflow: hidden;
+}
+
+.lace-modal--tone-danger {
+  border-color: var(--lace-toast-error-border);
+}
+
+.lace-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--lace-border-default);
+  flex-shrink: 0;
+}
+
+.lace-modal--tone-danger .lace-modal__header {
+  border-bottom-color: var(--lace-toast-error-border);
+}
+
+.lace-modal__title {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--lace-text-label);
+}
+
+.lace-modal--tone-danger .lace-modal__title {
+  color: var(--lace-text-danger-light);
+}
+
+.lace-modal__close {
+  background: none;
+  border: none;
+  padding: 0 4px;
+  color: var(--lace-text-muted);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.lace-modal__close:hover {
+  color: var(--lace-grey);
+}
+
+.lace-modal__body {
+  padding: 12px 16px;
+  overflow-y: auto;
+  flex: 1 1 auto;
+  min-height: 0;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.lace-modal__footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 16px;
+  border-top: 1px solid var(--lace-border-default);
+  flex-shrink: 0;
+}
+
+.lace-modal--tone-danger .lace-modal__footer {
+  border-top-color: var(--lace-toast-error-border);
+}

--- a/packages/ui/src/Modal/Modal.stories.tsx
+++ b/packages/ui/src/Modal/Modal.stories.tsx
@@ -1,0 +1,98 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from '../Button';
+import { Modal } from './Modal';
+
+const meta: Meta<typeof Modal> = {
+  title: 'UI / Modal',
+  component: Modal,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Centered dialog over a full-viewport backdrop. Backdrop click and the Escape key dismiss. Use `tone="danger"` for destructive confirmations and error dialogs. Consumers own the footer actions; Modal owns the chrome.',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ position: 'relative', width: '100vw', height: '100vh' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    open: true,
+    onClose: () => {},
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Modal>;
+
+export const Default: Story = {
+  args: {
+    title: 'Confirm rename',
+    children: (
+      <p style={{ margin: 0 }}>
+        Rename <code style={{ color: 'var(--lace-green)' }}>vpc</code> to{' '}
+        <code style={{ color: 'var(--lace-green)' }}>primary_vpc</code>? References in other modules
+        will be rewritten automatically.
+      </p>
+    ),
+    footer: (
+      <>
+        <Button variant="secondary">Cancel</Button>
+        <Button variant="primary">Rename</Button>
+      </>
+    ),
+  },
+};
+
+export const Danger: Story = {
+  args: {
+    title: 'Clear all modules?',
+    tone: 'danger',
+    children: (
+      <p style={{ margin: 0 }}>
+        This removes every module, binding, and group from the canvas. The underlying{' '}
+        <code style={{ color: 'var(--lace-green)' }}>.tf</code> files are not touched — re-generate
+        to reflect the cleared state.
+      </p>
+    ),
+    footer: (
+      <>
+        <Button variant="secondary">Cancel</Button>
+        <Button variant="danger">Clear all</Button>
+      </>
+    ),
+  },
+};
+
+export const LongContent: Story = {
+  args: {
+    title: 'Release notes — v1.4.0',
+    children: (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+        {Array.from({ length: 20 }, (_, i) => `change-${i + 1}`).map((key, i) => (
+          <p key={key} style={{ margin: 0 }}>
+            Change #{i + 1}: lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sit
+            amet ipsum vel orci laoreet fermentum.
+          </p>
+        ))}
+      </div>
+    ),
+    footer: <Button variant="primary">Got it</Button>,
+  },
+};
+
+export const NoFooter: Story = {
+  args: {
+    title: 'Heads up',
+    children: (
+      <p style={{ margin: 0 }}>
+        Lace saved your canvas layout. Close this dialog or press Escape to continue.
+      </p>
+    ),
+  },
+};

--- a/packages/ui/src/Modal/Modal.tsx
+++ b/packages/ui/src/Modal/Modal.tsx
@@ -1,0 +1,64 @@
+import { type ReactNode, useEffect } from 'react';
+import './Modal.css';
+
+export type ModalTone = 'default' | 'danger';
+
+export interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  title: ReactNode;
+  children: ReactNode;
+  footer?: ReactNode;
+  /** Applies a red-accented border + title for error/confirm-destructive dialogs. */
+  tone?: ModalTone;
+  /** Fixed modal width in px. Defaults to 520. */
+  width?: number;
+}
+
+export function Modal({
+  open,
+  onClose,
+  title,
+  children,
+  footer,
+  tone = 'default',
+  width = 520,
+}: ModalProps) {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="lace-modal-backdrop" onClick={onClose} role="presentation">
+      <div
+        className={`lace-modal lace-modal--tone-${tone}`}
+        role="dialog"
+        aria-modal="true"
+        style={{ width }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="lace-modal__header">
+          {typeof title === 'string' ? <h2 className="lace-modal__title">{title}</h2> : title}
+          <button
+            type="button"
+            className="lace-modal__close"
+            onClick={onClose}
+            aria-label="Close"
+            title="Close"
+          >
+            ×
+          </button>
+        </header>
+        <div className="lace-modal__body">{children}</div>
+        {footer ? <footer className="lace-modal__footer">{footer}</footer> : null}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/Modal/index.ts
+++ b/packages/ui/src/Modal/index.ts
@@ -1,0 +1,2 @@
+export type { ModalProps, ModalTone } from './Modal';
+export { Modal } from './Modal';

--- a/packages/ui/src/Panel/Panel.css
+++ b/packages/ui/src/Panel/Panel.css
@@ -1,0 +1,76 @@
+/* Panel primitive — side-panel surface with a header, scrollable body,
+ * and optional sticky footer. Replaces the ad-hoc PanelFrame in
+ * @lace/canvas. Composites position the panel (SlidePanel, fixed
+ * docking, etc.); Panel only owns the frame. */
+
+.lace-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--lace-bg-surface);
+  border-left: 1px solid var(--lace-border-default);
+  box-shadow: var(--lace-panel-shadow);
+  font-family: inherit;
+  color: var(--lace-grey);
+}
+
+.lace-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px;
+  border-bottom: 1px solid var(--lace-border-default);
+  flex-shrink: 0;
+}
+
+.lace-panel__title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--lace-text-label);
+}
+
+.lace-panel__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  background: var(--lace-bg-input);
+  border: 1px solid var(--lace-border-default);
+  border-radius: 6px;
+  color: var(--lace-grey);
+  font-size: 14px;
+  cursor: pointer;
+  transition:
+    background 120ms ease,
+    border-color 120ms ease;
+}
+
+.lace-panel__close:hover {
+  background: var(--lace-btn-secondary-hover);
+  border-color: var(--lace-border-input-hover);
+}
+
+.lace-panel__body {
+  flex: 1 1 auto;
+  min-height: 0;
+  padding: 16px;
+}
+
+.lace-panel__body--scrollable {
+  overflow-y: auto;
+  padding-bottom: 96px;
+}
+
+.lace-panel__footer {
+  flex-shrink: 0;
+  padding: 16px;
+  background: var(--lace-bg-surface);
+  border-top: 1px solid var(--lace-border-default);
+  position: sticky;
+  bottom: 0;
+  z-index: 1;
+}

--- a/packages/ui/src/Panel/Panel.stories.tsx
+++ b/packages/ui/src/Panel/Panel.stories.tsx
@@ -1,0 +1,109 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from '../Button';
+import { Panel } from './Panel';
+
+const meta: Meta<typeof Panel> = {
+  title: 'UI / Panel',
+  component: Panel,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Side-panel surface: header with title + close button, scrollable body, optional sticky footer. Composites position the panel (slide-in, docked, etc.); Panel owns the frame only.',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          position: 'relative',
+          width: 480,
+          height: 560,
+          background: 'var(--lace-night)',
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    onClose: () => {},
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Panel>;
+
+const SampleBody = (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: 12, fontSize: 13 }}>
+    <p style={{ margin: 0, color: 'var(--lace-text-muted)' }}>
+      Panel contents go here — module config, edge inspector, settings, etc. The body scrolls
+      vertically when content exceeds the frame.
+    </p>
+    {Array.from({ length: 12 }, (_, i) => `row-${i + 1}`).map((key, i) => (
+      <div
+        key={key}
+        style={{
+          background: 'var(--lace-bg-input)',
+          border: '1px solid var(--lace-border-default)',
+          borderRadius: 4,
+          padding: 8,
+          color: 'var(--lace-text-label)',
+        }}
+      >
+        Row {i + 1}
+      </div>
+    ))}
+  </div>
+);
+
+export const Default: Story = {
+  args: {
+    title: 'Module Config',
+    children: SampleBody,
+  },
+};
+
+export const WithFooter: Story = {
+  args: {
+    title: 'Module Config',
+    children: SampleBody,
+    footer: (
+      <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+        <Button variant="secondary">Cancel</Button>
+        <Button variant="primary">Save</Button>
+      </div>
+    ),
+  },
+};
+
+export const NonScrollable: Story = {
+  args: {
+    title: 'Empty State',
+    scrollable: false,
+    children: (
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          height: '100%',
+          color: 'var(--lace-text-muted)',
+          fontSize: 13,
+        }}
+      >
+        No module selected.
+      </div>
+    ),
+  },
+};
+
+export const NarrowWidth: Story = {
+  args: {
+    title: 'Mini',
+    width: 280,
+    children: SampleBody,
+  },
+};

--- a/packages/ui/src/Panel/Panel.tsx
+++ b/packages/ui/src/Panel/Panel.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from 'react';
+import './Panel.css';
+
+export interface PanelProps {
+  /** Header text or a custom node (e.g. title + badge). */
+  title: ReactNode;
+  /** Fires when the header's close button is clicked. */
+  onClose: () => void;
+  children: ReactNode;
+  /** Sticky footer slot for primary actions. */
+  footer?: ReactNode;
+  /** Body scrolls vertically when true (default). */
+  scrollable?: boolean;
+  /** Fixed panel width in px. */
+  width?: number;
+}
+
+export function Panel({
+  title,
+  onClose,
+  children,
+  footer,
+  scrollable = true,
+  width = 420,
+}: PanelProps) {
+  return (
+    <div className="lace-panel" style={{ width }}>
+      <header className="lace-panel__header">
+        {typeof title === 'string' ? <h3 className="lace-panel__title">{title}</h3> : title}
+        <button
+          type="button"
+          className="lace-panel__close"
+          onClick={onClose}
+          aria-label="Close"
+          title="Close"
+        >
+          ×
+        </button>
+      </header>
+      <div className={`lace-panel__body${scrollable ? ' lace-panel__body--scrollable' : ''}`}>
+        {children}
+      </div>
+      {footer ? <footer className="lace-panel__footer">{footer}</footer> : null}
+    </div>
+  );
+}

--- a/packages/ui/src/Panel/index.ts
+++ b/packages/ui/src/Panel/index.ts
@@ -1,0 +1,2 @@
+export type { PanelProps } from './Panel';
+export { Panel } from './Panel';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,4 +1,10 @@
+export type { BadgeProps, BadgeSize, BadgeVariant } from './Badge';
+export { Badge } from './Badge';
 export type { ButtonProps, ButtonSize, ButtonVariant } from './Button';
 export { Button } from './Button';
 export type { IconButtonProps, IconButtonSize, IconButtonVariant } from './IconButton';
 export { IconButton } from './IconButton';
+export type { ModalProps, ModalTone } from './Modal';
+export { Modal } from './Modal';
+export type { PanelProps } from './Panel';
+export { Panel } from './Panel';


### PR DESCRIPTION
## Summary

Three new `@lace/ui` primitives, plain CSS + `@lace/design-tokens`, stories colocated so Chromatic picks them up automatically.

- **Badge** — `neutral | info | success | danger` × `sm | md`. Covers the muted count pills in `AccordionSection`, the blue version-tag + red remove chip in `ModuleConfigPanel`, and any status chip added later.
- **Panel** — header (title + close) + scrollable body + optional sticky footer. Replaces `PanelFrame`'s API one-for-one so Session 6 config-panel refactors can swap it in without shape changes.
- **Modal** — backdrop + centered card with default / danger tones. Backdrop click and Escape dismiss. Covers the inline `ValidationErrorDialog` pattern and will back confirm dialogs later.

**Tokens added:** \`--lace-badge-{neutral,info,success,danger}-{bg,border,text}\`, \`--lace-panel-shadow\`, \`--lace-modal-shadow\`. \`info\` reuses the existing \`--lace-tag-*\` family so blue tag colors stay single-sourced.

Scope is primitives-only by design — composite migrations land in Sessions 4-6 alongside each composite's Tailwind-to-tokens sweep. This keeps the PR small and the Chromatic baselines focused.

## Stories new/changed in this PR

All new — accept all as baselines.

**UI / Badge**
- \`Neutral\`, \`Info\`, \`Success\`, \`Danger\` — single-variant pills
- \`AllVariants\` — row of all four at sm
- \`SizeMatrix\` — 4 variants × 2 sizes

**UI / Panel**
- \`Default\` — title + scrollable body of rows
- \`WithFooter\` — same body plus Cancel/Save footer (composed from \`Button\` primitive)
- \`NonScrollable\` — empty-state panel
- \`NarrowWidth\` — 280px variant

**UI / Modal**
- \`Default\` — confirm-rename dialog with Cancel/Rename buttons
- \`Danger\` — destructive confirm with red-accented border + title
- \`LongContent\` — 20-paragraph body to exercise body scroll + sticky footer
- \`NoFooter\` — headline-only dialog (backdrop/Escape to dismiss)

No changes to existing composites or stories — Toast/ContextMenu/ModuleNode/GroupNode/SlidePanel all untouched.

## Test plan

- [x] \`npx tsc --noEmit\` — zero errors
- [x] \`pnpm run test:unit\` — 118/118 pass
- [x] \`pnpm run lint\` — biome clean
- [x] Verified each story manually in Storybook via Playwright MCP
- [ ] Post-merge: review + accept all 12 new Chromatic baselines

🤖 Generated with [Claude Code](https://claude.com/claude-code)