### PR TITLE
refactor(canvas): ActionBar to plain CSS + tokens

### DIFF
--- a/packages/canvas/src/components/ActionBar.css
+++ b/packages/canvas/src/components/ActionBar.css
@@ -1,0 +1,74 @@
+/* ActionBar — top-right icon strip over the canvas. Plain CSS + tokens
+ * so the composite renders identically in the canvas bundle and in
+ * Storybook (Tailwind v4 doesn't scan @lace/canvas). Matches the
+ * ContextMenu/Toast pattern from Session 1.5. */
+
+.lace-action-bar {
+  display: flex;
+  align-items: center;
+  background: var(--lace-action-bar-bg);
+  backdrop-filter: blur(6px);
+  border: 1px solid var(--lace-border-default);
+  border-radius: 8px;
+  box-shadow: var(--lace-action-bar-shadow);
+  overflow: hidden;
+}
+
+.lace-action-bar__icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  color: var(--lace-text-muted);
+  cursor: pointer;
+  transition: color 120ms ease;
+}
+
+.lace-action-bar__icon-btn:hover:not(:disabled) {
+  color: var(--lace-grey);
+}
+
+.lace-action-bar__icon-btn:focus-visible {
+  outline: 2px solid var(--lace-green);
+  outline-offset: -2px;
+}
+
+.lace-action-bar__separator {
+  width: 1px;
+  height: 20px;
+  margin: 0 2px;
+  background: var(--lace-action-bar-separator);
+}
+
+.lace-action-bar__generate {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  background: var(--lace-action-bar-generate-bg);
+  border: none;
+  color: var(--lace-btn-text-primary);
+  cursor: pointer;
+  transition: background 120ms ease;
+}
+
+.lace-action-bar__generate:hover:not(:disabled) {
+  background: var(--lace-action-bar-generate-bg-hover);
+}
+
+.lace-action-bar__generate:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.lace-action-bar__icon {
+  width: 14px;
+  height: 14px;
+  fill: currentColor;
+}

--- a/packages/canvas/src/components/ActionBar.tsx
+++ b/packages/canvas/src/components/ActionBar.tsx
@@ -1,6 +1,5 @@
 import { Panel } from '@xyflow/react';
-
-// ── Types ──
+import './ActionBar.css';
 
 type ActionBarProps = {
   isGenerating?: boolean;
@@ -12,7 +11,43 @@ type ActionBarProps = {
   onOpenSettings: () => void;
 };
 
-// ── Component ──
+const ICON_VIEWBOX = '0 0 24 24';
+
+const SaveIcon = () => (
+  <svg className="lace-action-bar__icon" viewBox={ICON_VIEWBOX} aria-hidden="true">
+    <path d="M17 3H5a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2V7l-4-4zm-5 16a3 3 0 110-6 3 3 0 010 6zm3-10H5V5h10v4z" />
+  </svg>
+);
+
+const TrashIcon = () => (
+  <svg className="lace-action-bar__icon" viewBox={ICON_VIEWBOX} aria-hidden="true">
+    <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z" />
+  </svg>
+);
+
+const UndoIcon = () => (
+  <svg className="lace-action-bar__icon" viewBox={ICON_VIEWBOX} aria-hidden="true">
+    <path d="M12.5 8c-2.65 0-5.05.99-6.9 2.6L2 7v9h9l-3.62-3.62c1.39-1.16 3.16-1.88 5.12-1.88 3.54 0 6.55 2.31 7.6 5.5l2.37-.78C21.08 11.03 17.15 8 12.5 8z" />
+  </svg>
+);
+
+const RedoIcon = () => (
+  <svg className="lace-action-bar__icon" viewBox={ICON_VIEWBOX} aria-hidden="true">
+    <path d="M18.4 10.6C16.55 8.99 14.15 8 11.5 8c-4.65 0-8.58 3.03-9.96 7.22L3.9 16c1.05-3.19 4.05-5.5 7.6-5.5 1.95 0 3.73.72 5.12 1.88L13 16h9V7l-3.6 3.6z" />
+  </svg>
+);
+
+const GenerateIcon = () => (
+  <svg className="lace-action-bar__icon" viewBox={ICON_VIEWBOX} aria-hidden="true">
+    <path d="M7.5 5.6L10 7 8.6 4.5 10 2 7.5 3.4 5 2l1.4 2.5L5 7zm12 9.8L17 14l1.4 2.5L17 19l2.5-1.4L22 19l-1.4-2.5L22 14zM22 2l-2.5 1.4L17 2l1.4 2.5L17 7l2.5-1.4L22 7l-1.4-2.5zm-7.63 5.29a.996.996 0 00-1.41 0L1.29 18.96a.996.996 0 000 1.41l2.34 2.34c.39.39 1.02.39 1.41 0L16.7 11.05a.996.996 0 000-1.41l-2.33-2.35zm-1.97 5.67L7.73 8.29l2.07-2.07 4.67 4.67-2.07 2.07z" />
+  </svg>
+);
+
+const SettingsIcon = () => (
+  <svg className="lace-action-bar__icon" viewBox={ICON_VIEWBOX} aria-hidden="true">
+    <path d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58a.49.49 0 00.12-.61l-1.92-3.32a.488.488 0 00-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54a.484.484 0 00-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.07.62-.07.94s.02.64.07.94l-2.03 1.58a.49.49 0 00-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6a3.6 3.6 0 110-7.2 3.6 3.6 0 010 7.2z" />
+  </svg>
+);
 
 export default function ActionBar({
   isGenerating,
@@ -25,82 +60,64 @@ export default function ActionBar({
 }: ActionBarProps) {
   return (
     <Panel position="top-right">
-      <div className="flex items-center gap-0 bg-[#1e1e1e]/80 backdrop-blur border border-[#333] rounded-lg shadow-[0_2px_8px_rgba(0,0,0,0.4)]">
-        {/* Left group: utility actions */}
+      <div className="lace-action-bar">
         <button
+          type="button"
+          className="lace-action-bar__icon-btn"
           onClick={onSave}
           title="Save (Cmd+S)"
           aria-label="Save"
-          className="w-8 h-8 flex items-center justify-center bg-transparent border-none text-[#999] hover:text-white cursor-pointer rounded-l-lg"
         >
-          <svg viewBox="0 0 24 24" fill="currentColor" width="14" height="14">
-            <path d="M17 3H5a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2V7l-4-4zm-5 16a3 3 0 110-6 3 3 0 010 6zm3-10H5V5h10v4z" />
-          </svg>
+          <SaveIcon />
         </button>
-
         <button
+          type="button"
+          className="lace-action-bar__icon-btn"
           onClick={onClearGraph}
           title="Clear all modules"
           aria-label="Clear all"
-          className="w-8 h-8 flex items-center justify-center bg-transparent border-none text-[#999] hover:text-white cursor-pointer"
         >
-          <svg viewBox="0 0 24 24" fill="currentColor" width="14" height="14">
-            <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z" />
-          </svg>
+          <TrashIcon />
         </button>
-
         <button
+          type="button"
+          className="lace-action-bar__icon-btn"
           onClick={onUndo}
           title="Undo (Cmd+Z)"
           aria-label="Undo"
-          className="w-8 h-8 flex items-center justify-center bg-transparent border-none text-[#999] hover:text-white cursor-pointer"
         >
-          <svg viewBox="0 0 24 24" fill="currentColor" width="14" height="14">
-            <path d="M12.5 8c-2.65 0-5.05.99-6.9 2.6L2 7v9h9l-3.62-3.62c1.39-1.16 3.16-1.88 5.12-1.88 3.54 0 6.55 2.31 7.6 5.5l2.37-.78C21.08 11.03 17.15 8 12.5 8z" />
-          </svg>
+          <UndoIcon />
         </button>
-
         <button
+          type="button"
+          className="lace-action-bar__icon-btn"
           onClick={onRedo}
           title="Redo (Cmd+Shift+Z)"
           aria-label="Redo"
-          className="w-8 h-8 flex items-center justify-center bg-transparent border-none text-[#999] hover:text-white cursor-pointer"
         >
-          <svg viewBox="0 0 24 24" fill="currentColor" width="14" height="14">
-            <path d="M18.4 10.6C16.55 8.99 14.15 8 11.5 8c-4.65 0-8.58 3.03-9.96 7.22L3.9 16c1.05-3.19 4.05-5.5 7.6-5.5 1.95 0 3.73.72 5.12 1.88L13 16h9V7l-3.6 3.6z" />
-          </svg>
+          <RedoIcon />
         </button>
 
-        {/* Separator */}
-        <div className="w-px h-5 bg-[#444] mx-0.5" />
+        <div className="lace-action-bar__separator" aria-hidden="true" />
 
-        {/* Right group: project actions */}
         <button
+          type="button"
+          className="lace-action-bar__generate"
           onClick={onGenerate}
           disabled={isGenerating}
           title="Generate Terraform files"
           aria-label="Generate"
-          className={`w-8 h-8 flex items-center justify-center border-none text-white ${
-            isGenerating
-              ? 'bg-[#2ea043]/50 opacity-50 cursor-not-allowed'
-              : 'bg-[#2ea043] cursor-pointer hover:bg-[#3ab550]'
-          }`}
         >
-          <svg viewBox="0 0 24 24" fill="currentColor" width="14" height="14">
-            <path d="M7.5 5.6L10 7 8.6 4.5 10 2 7.5 3.4 5 2l1.4 2.5L5 7zm12 9.8L17 14l1.4 2.5L17 19l2.5-1.4L22 19l-1.4-2.5L22 14zM22 2l-2.5 1.4L17 2l1.4 2.5L17 7l2.5-1.4L22 7l-1.4-2.5zm-7.63 5.29a.996.996 0 00-1.41 0L1.29 18.96a.996.996 0 000 1.41l2.34 2.34c.39.39 1.02.39 1.41 0L16.7 11.05a.996.996 0 000-1.41l-2.33-2.35zm-1.97 5.67L7.73 8.29l2.07-2.07 4.67 4.67-2.07 2.07z" />
-          </svg>
+          <GenerateIcon />
         </button>
-
-        {/* Gear button — opens unified settings panel */}
         <button
+          type="button"
+          className="lace-action-bar__icon-btn"
           onClick={onOpenSettings}
           title="Settings"
           aria-label="Settings"
-          className="w-8 h-8 flex items-center justify-center bg-transparent border-none text-[#999] hover:text-white cursor-pointer rounded-r-lg"
         >
-          <svg viewBox="0 0 24 24" fill="currentColor" width="14" height="14">
-            <path d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58a.49.49 0 00.12-.61l-1.92-3.32a.488.488 0 00-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54a.484.484 0 00-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.07.62-.07.94s.02.64.07.94l-2.03 1.58a.49.49 0 00-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6a3.6 3.6 0 110-7.2 3.6 3.6 0 010 7.2z" />
-          </svg>
+          <SettingsIcon />
         </button>
       </div>
     </Panel>

--- a/packages/design-tokens/tokens.css
+++ b/packages/design-tokens/tokens.css
@@ -70,6 +70,13 @@
   --lace-mode-toggle-inactive-hover-border: var(--lace-border-input-hover);
   --lace-mode-toggle-inactive-hover-text: var(--lace-grey);
 
+  /* ── ActionBar ── */
+  --lace-action-bar-bg: rgba(30, 30, 30, 0.8);
+  --lace-action-bar-separator: #444444;
+  --lace-action-bar-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+  --lace-action-bar-generate-bg: var(--lace-accent-green);
+  --lace-action-bar-generate-bg-hover: #3ab550;
+
   /* ── Toast ── */
   --lace-toast-success-bg: #153238;
   --lace-toast-success-border: rgba(206, 254, 101, 0.2);


### PR DESCRIPTION
## Summary

ActionBar was styled entirely via Tailwind arbitrary-value classes (\`bg-[#1e1e1e]/80\`, \`border-[#333]\`, \`text-[#999]\`, \`bg-[#2ea043]\`). Tailwind v4 in the Storybook build only scans \`canvas-stories\`, not \`@lace/canvas\`, so those utilities never compiled — the Flows/Mock/* stories from PR #89 surfaced the broken render.

Fix mirrors Session 1.5's ContextMenu + Toast conversion: colocated \`ActionBar.css\` using \`--lace-*\` tokens, SVG icons extracted to named components.

**Tokens added:** \`--lace-action-bar-{bg,separator,shadow,generate-bg,generate-bg-hover}\`. \`generate-bg\` reuses \`--lace-accent-green\` since the magic-wand button color matched exactly.

## Stories new/changed in this PR

No new stories. Visual impact: **every \`Flows/Mock/*\` story** now shows a correctly-rendered ActionBar in the top-right (Save / Trash / Undo / Redo / separator / green Generate with magic-wand icon / Settings). Confirmed locally via Playwright MCP against IamStack mock story.

The Chromatic baselines from PR #89 (the original Flows/Mock/* snapshots) should be **denied** — this PR is the fix-forward. New baselines produced by this merge are the ones to accept.

## Test plan

- [x] \`npx tsc --noEmit\` — zero errors
- [x] \`pnpm run test:unit\` — 123/123 pass
- [x] \`pnpm run lint\` — biome clean
- [x] IamStack mock story verified in Storybook — ActionBar renders correctly
- [ ] Post-merge: deny the PR #89 mock-story baselines and accept the new ones from this merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)