### PR TITLE
fix(canvas): overlay positions — ActionBar top-right, MiniMap+Controls bottom-left, Toast top-right

### DIFF
--- a/packages/canvas-stories/src/stories/Toast.stories.tsx
+++ b/packages/canvas-stories/src/stories/Toast.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof Toast> = {
   decorators: [
     (Story) => (
       <div
-        style={{ position: 'relative', width: 400, height: 120, background: 'var(--lace-night)' }}
+        style={{ position: 'relative', width: 480, height: 200, background: 'var(--lace-night)' }}
       >
         <Story />
       </div>

--- a/packages/canvas/src/Canvas.tsx
+++ b/packages/canvas/src/Canvas.tsx
@@ -302,12 +302,24 @@ function CompositeEditor({
       proOptions={{ hideAttribution: true }}
       style={{ background: '#161616' }}
     >
+      {/* Bottom-left stack: Controls at the floor, MiniMap above.
+          116px = Controls height (84px, 3×28px buttons) + gap (12px) + floor (20px).
+          Inline offsets instead of @lace/canvas/index.css overrides so
+          Storybook (which doesn't import that stylesheet) matches the
+          webview build. */}
       <MiniMap
-        style={{ background: '#111', border: '1px solid #333', borderRadius: 4 }}
+        position="bottom-left"
+        style={{
+          background: '#111',
+          border: '1px solid #333',
+          borderRadius: 4,
+          bottom: 116,
+          left: 20,
+        }}
         maskColor="rgba(0,0,0,0.6)"
         nodeColor="#CEFE65"
       />
-      <Controls position="bottom-left" showInteractive={false} />
+      <Controls position="bottom-left" showInteractive={false} style={{ bottom: 20, left: 20 }} />
       <ActionBar
         isGenerating={isGenerating}
         onSave={onSave}
@@ -568,7 +580,16 @@ export default function Canvas() {
       return <ErrorState message={state.error} />;
     }
     return (
-      <div className="h-screen flex items-center justify-center text-[#999] text-sm">
+      <div
+        style={{
+          height: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: 'var(--lace-text-muted)',
+          fontSize: 13,
+        }}
+      >
         Loading canvas...
       </div>
     );
@@ -581,8 +602,14 @@ export default function Canvas() {
   const view = state.view;
 
   // ── Render ──
+  // Inline layout instead of Tailwind utilities so this works in Storybook
+  // (Tailwind v4 only scans canvas-stories, not @lace/canvas). Children
+  // rely on the outer 100vh height to place xyflow's bottom-docked panels
+  // correctly — without it the ReactFlow container collapses.
   return (
-    <div className="h-screen flex flex-col relative">
+    <div
+      style={{ position: 'relative', display: 'flex', flexDirection: 'column', height: '100vh' }}
+    >
       <Toast toast={toast} />
       <ContextMenu
         contextMenu={contextMenu}
@@ -609,7 +636,7 @@ export default function Canvas() {
         />
       )}
 
-      <div className="flex-1 relative min-h-0">
+      <div style={{ position: 'relative', flex: '1 1 auto', minHeight: 0 }}>
         <CompositeEditor
           view={view}
           isGenerating={generating}

--- a/packages/canvas/src/components/Toast.css
+++ b/packages/canvas/src/components/Toast.css
@@ -3,10 +3,12 @@
  * utilities so the component renders identically in the canvas bundle
  * and in Storybook (where Tailwind v4 doesn't scan @lace/canvas). */
 
+/* Top-right corner, below the ActionBar. ActionBar is ~48px tall + its
+ * xyflow Panel offset, so 60px clears it cleanly. */
 .lace-toast {
   position: absolute;
-  top: 16px;
-  left: 16px;
+  top: 60px;
+  right: 16px;
   z-index: 20;
   display: flex;
   align-items: center;

--- a/packages/canvas/src/components/ValidationErrorBanner.tsx
+++ b/packages/canvas/src/components/ValidationErrorBanner.tsx
@@ -150,9 +150,10 @@ export function ValidationErrorBanner({
 
   return (
     <>
-      {/* Persistent banner — same top-left position as toast */}
+      {/* Persistent banner — top-right, below the ActionBar. Matches Toast's
+          60px/16px offset so banner and toast visually align. */}
       <div
-        className="absolute top-4 left-4 z-20 flex items-center gap-2 px-3 py-1.5 rounded-md text-xs shadow-[0_2px_6px_rgba(0,0,0,0.3)] border"
+        className="absolute top-[60px] right-4 z-20 flex items-center gap-2 px-3 py-1.5 rounded-md text-xs shadow-[0_2px_6px_rgba(0,0,0,0.3)] border"
         style={{
           background: '#3a1518',
           color: '#f87171',

--- a/packages/canvas/src/index.css
+++ b/packages/canvas/src/index.css
@@ -43,8 +43,10 @@
 }
 
 /* ── Controls ──
- * ReactFlow Panel sets .bottom { bottom: 0 } and .right { right: 0 }
- * in @layer components. We override to inset from edges.
+ * Bottom-left corner offsets live on the Controls component's `style`
+ * prop in Canvas.tsx (alongside MiniMap's stack offset), so the layout
+ * works identically in the webview and in Storybook — Storybook doesn't
+ * import this stylesheet.
  */
 
 .react-flow__controls {
@@ -52,11 +54,6 @@
   border-radius: 6px;
   overflow: hidden;
   border: 1px solid rgba(206, 254, 101, 0.15);
-}
-
-.react-flow__panel.bottom.right {
-  bottom: 40px;
-  right: 20px;
 }
 
 .react-flow__controls-button {
@@ -93,11 +90,6 @@
 }
 
 /* ── MiniMap ── */
-
-.react-flow__panel.bottom.left {
-  bottom: 40px;
-  left: 20px;
-}
 
 .react-flow__minimap {
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);


### PR DESCRIPTION
## Summary

The Flows/Mock/* stories from PR #89 revealed two layout bugs:

1. **MiniMap defaulted to bottom-right**, stacked visually under the ActionBar in the same corner.
2. **Canvas's root wrapper used Tailwind's \`h-screen flex flex-col relative\`** which Tailwind v4 doesn't compile in the Storybook build (only scans canvas-stories). The ReactFlow container collapsed to 150px tall, so xyflow's bottom-docked panels rendered near the top.

Layout contract (now):
- **Top right**: ActionBar (always); Toast + ValidationErrorBanner at \`top: 60px\` to clear the ActionBar's ~48px height.
- **Bottom left**: Controls stacked under MiniMap — \`bottom: 20\` (Controls floor) and \`bottom: 116\` (MiniMap = 20 + 84px Controls + 12px gap).

Positions live on the components' \`style\` props instead of \`@lace/canvas/index.css\` overrides so Storybook matches the webview build — Storybook's preview.css doesn't import that stylesheet.

Canvas's root wrapper switched from Tailwind classes to inline flex + \`height: 100vh\` for the same reason (same root cause as the ActionBar Tailwind fix in PR #90).

## Stories new/changed in this PR

No new stories. Visual impact:

- **Every \`Flows/Mock/*\` story** now uses the full iframe height and shows the correct corner layout (ActionBar top-right, MiniMap + Controls stacked bottom-left).
- **\`Components/Toast\`** decorator widened to 480×200 so the new \`top: 60\` offset lands visibly within the story frame. All 4 Toast stories (Success, ErrorState, Progress Generating, Progress Formatting) now position at top-right instead of top-left.

The PR #89 and PR #90 baselines should be **denied**; this PR's baselines are the ones to accept.

## Test plan

- [x] \`npx tsc --noEmit\` — zero errors
- [x] \`pnpm run test:unit\` — 123/123 pass
- [x] \`pnpm run lint\` — biome clean
- [x] IamStack mock story verified in Storybook: ActionBar top-right, MiniMap + Controls bottom-left
- [x] DOM inspection confirmed MiniMap at y=bottom-\~150, Controls at y=bottom-20
- [ ] Post-merge: deny stale baselines, accept the new layout in Chromatic

🤖 Generated with [Claude Code](https://claude.com/claude-code)