### PR TITLE
refactor(canvas): design-system foundation (tokens, Canvas.css, scene stories)

### DIFF
--- a/packages/canvas-stories/.storybook/preview.css
+++ b/packages/canvas-stories/.storybook/preview.css
@@ -1,18 +1,19 @@
-/* Storybook preview CSS — mirrors the canvas webview's CSS order */
+/*
+ * Storybook preview CSS. Mirrors the @lace/canvas webview entry so
+ * stories load exactly the same global stylesheets the webview does —
+ * any per-component xyflow overrides come in via Canvas.css through
+ * the React import chain, not from here.
+ */
+
 @import "tailwindcss";
 @import "@xyflow/react/dist/style.css" layer(components);
 @import "@lace/design-tokens/tokens.css";
 
-body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  background: var(--lace-night);
-  color: var(--lace-grey);
-  margin: 0;
-  padding: 0;
-}
-
-/* Storybook centers components by default; ensure enough space */
+/* Storybook centers components by default; give isolated primitive
+ * stories a little breathing room. Full-screen stories (layout:
+ * 'fullscreen' — every flow/mock + most composite stories) are
+ * unaffected because the centred iframe root isn't used for them. */
 #storybook-root {
   min-width: 320px;
-  padding: 16px;
+  padding: var(--lace-space-4);
 }

--- a/packages/canvas-stories/src/decorators/mock-flow-decorator.tsx
+++ b/packages/canvas-stories/src/decorators/mock-flow-decorator.tsx
@@ -1,6 +1,6 @@
 import { App, type HostBridge } from '@lace/canvas';
 import type { CanvasView } from '@lace/proto';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { MockCanvasEngine } from '../mocks/mock-engine';
 
 // Noop bridge — mock flow stories are static snapshots, so host signals
@@ -20,6 +20,13 @@ function makeMockBridge(engine: MockCanvasEngine): HostBridge {
 
 type Props = {
   fixture: CanvasView;
+  /**
+   * Optional hook scene stories use to pin the canvas into a specific
+   * UI state after the initial view mounts — e.g. fire a synthetic
+   * `generateSuccess` to make the save toast appear. Runs on the
+   * microtask after mount so subscriptions have landed.
+   */
+  onReady?: (engine: MockCanvasEngine) => void;
 };
 
 /**
@@ -28,9 +35,17 @@ type Props = {
  * captured by `scripts/capture-fixtures.mjs`. Stories using this decorator
  * snapshot in Chromatic's cloud without any backend.
  */
-export function MockFlowDecorator({ fixture }: Props) {
+export function MockFlowDecorator({ fixture, onReady }: Props) {
   const engine = useMemo(() => new MockCanvasEngine(fixture), [fixture]);
   const hostBridge = useMemo(() => makeMockBridge(engine), [engine]);
+
+  useEffect(() => {
+    if (!onReady) return;
+    // Deferred past the stateUpdated microtask so listeners have seen
+    // the initial view before we start injecting state transitions.
+    const timer = setTimeout(() => onReady(engine), 0);
+    return () => clearTimeout(timer);
+  }, [engine, onReady]);
 
   return (
     <div style={{ position: 'relative', width: '100%', height: '100vh' }}>

--- a/packages/canvas-stories/src/mocks/mock-engine.ts
+++ b/packages/canvas-stories/src/mocks/mock-engine.ts
@@ -155,7 +155,12 @@ export class MockCanvasEngine implements CanvasEngine {
     };
   }
 
-  private emit(event: EngineEvent): void {
+  /**
+   * Fire a synthetic event. Scene stories use this to drive the canvas
+   * into specific UI states (toast visible, banner showing, etc.)
+   * without exercising real mutations.
+   */
+  emit(event: EngineEvent): void {
     for (const listener of this.listeners) listener(event);
   }
 }

--- a/packages/canvas-stories/src/stories/flows/scene/Generating.stories.tsx
+++ b/packages/canvas-stories/src/stories/flows/scene/Generating.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { MockFlowDecorator } from '../../../decorators/mock-flow-decorator';
+import { iamStackFixture } from '../../../mocks/fixtures';
+
+// Scene — canvas mid-generation, progress toast with spinner. Pairs
+// with SaveSuccess to lock both transient and success toast visuals.
+
+const meta: Meta = {
+  title: 'Flows/Scene/Generating',
+  parameters: { layout: 'fullscreen' },
+};
+export default meta;
+
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => (
+    <MockFlowDecorator
+      fixture={iamStackFixture}
+      onReady={(engine) => {
+        // Progress toasts already don't auto-dismiss (they clear when a
+        // Success/Error event supersedes them), so no durationMs needed.
+        engine.emit({ type: 'generateProgress', phase: 'generating' });
+      }}
+    />
+  ),
+};

--- a/packages/canvas-stories/src/stories/flows/scene/SaveSuccess.stories.tsx
+++ b/packages/canvas-stories/src/stories/flows/scene/SaveSuccess.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { MockFlowDecorator } from '../../../decorators/mock-flow-decorator';
+import { iamStackFixture } from '../../../mocks/fixtures';
+
+// Scene — canvas with multiple nodes + save-success toast visible in
+// the top-right. Covers the "ActionBar + Toast in the same corner"
+// layout case that isolated stories cannot exercise.
+
+const meta: Meta = {
+  title: 'Flows/Scene/SaveSuccess',
+  parameters: { layout: 'fullscreen' },
+};
+export default meta;
+
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => (
+    <MockFlowDecorator
+      fixture={iamStackFixture}
+      onReady={(engine) => {
+        // Simulate a just-completed successful generation. `toastDurationMs:
+        // Infinity` pins the success toast so Chromatic snapshots the
+        // "ActionBar + Toast stacked top-right" layout rather than a
+        // cleared viewport 1.5s later.
+        engine.emit({
+          type: 'generateSuccess',
+          files: ['main.tf'],
+          toastDurationMs: Number.POSITIVE_INFINITY,
+        });
+      }}
+    />
+  ),
+};

--- a/packages/canvas-stories/src/stories/flows/scene/ValidationError.stories.tsx
+++ b/packages/canvas-stories/src/stories/flows/scene/ValidationError.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { MockFlowDecorator } from '../../../decorators/mock-flow-decorator';
+import { iamStackFixture } from '../../../mocks/fixtures';
+
+// Scene — canvas with a failed validation showing the persistent
+// ValidationErrorBanner + its dismiss affordance. Covers the
+// "banner-over-canvas, top-right, below ActionBar" layout case.
+
+const meta: Meta = {
+  title: 'Flows/Scene/ValidationError',
+  parameters: { layout: 'fullscreen' },
+};
+export default meta;
+
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => (
+    <MockFlowDecorator
+      fixture={iamStackFixture}
+      onReady={(engine) => {
+        // `toastDurationMs: 0` clears the transient error toast
+        // effectively instantly so the persistent ValidationErrorBanner
+        // is the story's focus — it's hidden while a toast is active.
+        engine.emit({
+          type: 'generateError',
+          toastDurationMs: 0,
+          message: 'Terraform validation failed',
+          diagnostics: [
+            {
+              severity: 'error',
+              message: 'Required input "role_name" is not set on attachment.',
+              instance_id: 'attachment',
+              file: 'main.tf',
+              line: 12,
+              column: 3,
+            },
+            {
+              severity: 'error',
+              message: 'Invalid value for input "policy_arn" on attachment.',
+              instance_id: 'attachment',
+            },
+          ],
+        });
+      }}
+    />
+  ),
+};

--- a/packages/canvas/src/Canvas.css
+++ b/packages/canvas/src/Canvas.css
@@ -1,0 +1,129 @@
+/*
+ * Canvas.css — xyflow (@xyflow/react) customisations for the Lace canvas.
+ *
+ * Colocated with Canvas.tsx (imported there) so both the VS Code webview
+ * bundle and the Storybook canvas-stories build pick these rules up via
+ * the React import chain. There is no separate global stylesheet for the
+ * canvas — that was the source of the webview↔Storybook divergence.
+ *
+ * Layer ordering note:
+ *   xyflow ships its own stylesheet under @layer components. Our rules
+ *   below are unlayered, so they beat @layer rules without needing
+ *   !important. Only the rules that explicitly need to live inside
+ *   @layer components (e.g. the edge stroke override that competes with
+ *   the xyflow default) are placed there.
+ */
+
+/* ── Pin handles (Blender-style typed I/O) ──
+ * Colors are set per-pin via inline style (pinColor.ts maps type → RGB).
+ * The shared rules cover geometry and hover/connecting states. */
+
+.lace-pin-handle {
+  border-radius: var(--lace-radius-pill);
+  opacity: 0.9;
+  transition:
+    opacity var(--lace-duration-fast) var(--lace-easing-standard),
+    transform var(--lace-duration-fast) var(--lace-easing-standard);
+}
+
+.lace-pin-handle:hover {
+  opacity: 1;
+  transform: scale(1.25);
+}
+
+.react-flow__handle.lace-pin-handle.connectingfrom,
+.react-flow__handle.lace-pin-handle.connectingto {
+  opacity: 1;
+  transform: scale(1.35);
+}
+
+/* ── Controls (zoom in / zoom out / fit) ──
+ * xyflow's defaults give us a white-on-white result. We override with
+ * the brand gunmetal + accent-green so controls are legible against
+ * the night-black canvas. */
+
+.react-flow__controls {
+  border-radius: var(--lace-radius-md);
+  overflow: hidden;
+  border: 1px solid var(--lace-canvas-controls-border);
+  box-shadow: var(--lace-shadow-md);
+}
+
+.react-flow__controls-button {
+  width: 28px;
+  height: 28px;
+  padding: 5px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--lace-canvas-controls-bg);
+  border: none;
+  border-bottom: 1px solid var(--lace-color-accent-alpha-subtle);
+  cursor: pointer;
+  transition: background var(--lace-duration-fast) var(--lace-easing-standard);
+}
+
+.react-flow__controls-button:last-child {
+  border-bottom: none;
+}
+
+.react-flow__controls-button:hover {
+  background: var(--lace-canvas-controls-bg-hover);
+}
+
+.react-flow__controls-button svg {
+  width: 13px;
+  height: 13px;
+  max-width: 13px;
+  max-height: 13px;
+  fill: var(--lace-canvas-controls-icon);
+  transition: fill var(--lace-duration-fast) var(--lace-easing-standard);
+}
+
+.react-flow__controls-button:hover svg {
+  fill: var(--lace-canvas-controls-icon-hover);
+}
+
+/* ── MiniMap ── */
+
+.react-flow__minimap {
+  border-radius: var(--lace-radius-md);
+  overflow: hidden;
+  border: 1px solid var(--lace-canvas-minimap-border);
+  box-shadow: var(--lace-shadow-md);
+}
+
+/* ── Edges ──
+ * Default edges use the brand green. Selected edges get a brighter
+ * stroke + drop-shadow so the user can see what will be deleted on
+ * keypress. */
+
+.react-flow__edge path {
+  stroke: var(--lace-canvas-edge-stroke);
+  stroke-width: var(--lace-canvas-edge-stroke-width);
+  transition:
+    stroke var(--lace-duration-fast) var(--lace-easing-standard),
+    stroke-width var(--lace-duration-fast) var(--lace-easing-standard),
+    filter var(--lace-duration-fast) var(--lace-easing-standard);
+}
+
+.react-flow__edge.selected path {
+  stroke: var(--lace-canvas-edge-stroke-selected);
+  stroke-width: var(--lace-canvas-edge-stroke-width-selected);
+  filter: drop-shadow(0 0 4px var(--lace-color-green-alpha-60));
+}
+
+.react-flow__edge:hover path {
+  stroke: var(--lace-canvas-edge-stroke-selected);
+  stroke-width: 2px;
+}
+
+/* ── Slide panel ── */
+
+.slide-panel {
+  position: absolute;
+  right: 0;
+  top: 0;
+  height: 100%;
+  transition: transform var(--lace-duration-medium) var(--lace-easing-out);
+}

--- a/packages/canvas/src/Canvas.tsx
+++ b/packages/canvas/src/Canvas.tsx
@@ -1,5 +1,6 @@
 // src/webview/Canvas.tsx
 
+import './Canvas.css';
 import {
   applyEdgeChanges,
   applyNodeChanges,
@@ -300,24 +301,26 @@ function CompositeEditor({
       deleteKeyCode={['Backspace', 'Delete']}
       fitView={false}
       proOptions={{ hideAttribution: true }}
-      style={{ background: '#161616' }}
+      style={{ background: 'var(--lace-color-bg-canvas)' }}
     >
       {/* Bottom-left stack: Controls at the floor, MiniMap above.
-          116px = Controls height (84px, 3×28px buttons) + gap (12px) + floor (20px).
-          Inline offsets instead of @lace/canvas/index.css overrides so
-          Storybook (which doesn't import that stylesheet) matches the
-          webview build. */}
+          108px = Controls height (84px, 3×28px buttons) + gap (8px) + floor (20px − 4px
+          minimap bleed).
+          Inline offsets because Controls/MiniMap render at the ReactFlow
+          pane root; `style` is xyflow's first-class positioning API and
+          behaves identically in the webview and Storybook. Colors flow
+          through design tokens. */}
       <MiniMap
         position="bottom-left"
         style={{
-          background: '#111',
-          border: '1px solid #333',
-          borderRadius: 4,
-          bottom: 116,
+          width: 160,
+          height: 110,
+          background: 'var(--lace-canvas-minimap-bg)',
+          bottom: 108,
           left: 20,
         }}
-        maskColor="rgba(0,0,0,0.6)"
-        nodeColor="#CEFE65"
+        maskColor="var(--lace-canvas-minimap-mask)"
+        nodeColor="var(--lace-color-accent)"
       />
       <Controls position="bottom-left" showInteractive={false} style={{ bottom: 20, left: 20 }} />
       <ActionBar

--- a/packages/canvas/src/__tests__/useGenerationStatus.test.ts
+++ b/packages/canvas/src/__tests__/useGenerationStatus.test.ts
@@ -73,7 +73,7 @@ describe('useGenerationStatus', () => {
     });
 
     expect(result.current.generating).toBe(true);
-    expect(showToast).toHaveBeenCalledWith('Generating Terraform...', 'progress');
+    expect(showToast).toHaveBeenCalledWith('Generating Terraform...', 'progress', undefined);
   });
 
   test('generateSuccess resets generating and clears errors', () => {
@@ -93,7 +93,7 @@ describe('useGenerationStatus', () => {
 
     expect(result.current.generating).toBe(false);
     expect(result.current.validationErrors).toEqual([]);
-    expect(showToast).toHaveBeenCalledWith('Successfully generated', 'success');
+    expect(showToast).toHaveBeenCalledWith('Successfully generated', 'success', undefined);
   });
 
   test('generateError populates validation errors', () => {
@@ -114,7 +114,7 @@ describe('useGenerationStatus', () => {
     expect(result.current.generating).toBe(false);
     expect(result.current.validationErrors).toHaveLength(1);
     expect(result.current.validationErrors[0].message).toBe('Missing required input');
-    expect(showToast).toHaveBeenCalledWith('Validation: 1 error(s)', 'error');
+    expect(showToast).toHaveBeenCalledWith('Validation: 1 error(s)', 'error', undefined);
   });
 
   test('erroredNodeIds extracts instance_id from diagnostics', () => {

--- a/packages/canvas/src/components/ValidationErrorBanner.css
+++ b/packages/canvas/src/components/ValidationErrorBanner.css
@@ -1,0 +1,156 @@
+/* ValidationErrorBanner — persistent top-right banner shown after a
+ * failed `terraform validate`. Paired with a modal dialog that lists
+ * every diagnostic. All colors/spacing flow through design tokens so
+ * Storybook and the webview render identically. */
+
+.lace-error-banner {
+  position: absolute;
+  top: 60px;
+  right: var(--lace-space-4);
+  z-index: var(--lace-z-chrome);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--lace-space-2);
+  padding: var(--lace-space-1) var(--lace-space-3);
+  background: var(--lace-toast-error-bg);
+  border: 1px solid var(--lace-toast-error-border);
+  border-radius: var(--lace-radius-md);
+  color: var(--lace-color-text-danger-soft);
+  font-size: var(--lace-font-size-md);
+  line-height: var(--lace-line-height-tight);
+  box-shadow: var(--lace-shadow-sm);
+}
+
+.lace-error-banner__icon {
+  flex-shrink: 0;
+}
+
+.lace-error-banner__message {
+  white-space: nowrap;
+}
+
+.lace-error-banner__view-details {
+  padding: 1px 7px;
+  background: var(--lace-color-red-alpha-12);
+  border: 1px solid var(--lace-color-red-alpha-30);
+  border-radius: var(--lace-radius-sm);
+  color: var(--lace-color-text-danger-soft);
+  font-size: var(--lace-font-size-sm);
+  cursor: pointer;
+  transition: background var(--lace-duration-fast) var(--lace-easing-standard);
+}
+
+.lace-error-banner__view-details:hover {
+  background: var(--lace-color-red-alpha-20);
+}
+
+.lace-error-banner__dismiss {
+  padding: 0 var(--lace-space-1);
+  background: none;
+  border: none;
+  color: var(--lace-color-text-muted);
+  font-size: var(--lace-font-size-xl);
+  line-height: 1;
+  cursor: pointer;
+  transition: color var(--lace-duration-fast) var(--lace-easing-standard);
+}
+
+.lace-error-banner__dismiss:hover {
+  color: var(--lace-color-text-primary);
+}
+
+/* ── Dialog ── */
+
+.lace-error-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: var(--lace-z-overlay);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--lace-modal-backdrop);
+}
+
+.lace-error-dialog {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: 520px;
+  max-height: 70vh;
+  background: var(--lace-color-bg-context-menu);
+  border: 1px solid var(--lace-color-red-alpha-35);
+  border-radius: var(--lace-radius-lg);
+  box-shadow: var(--lace-shadow-xl);
+}
+
+.lace-error-dialog__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--lace-space-3) var(--lace-space-4);
+  border-bottom: 1px solid var(--lace-color-red-alpha-20);
+}
+
+.lace-error-dialog__title {
+  margin: 0;
+  color: var(--lace-color-text-danger-soft);
+  font-size: var(--lace-font-size-lg);
+  font-weight: var(--lace-font-weight-semibold);
+}
+
+.lace-error-dialog__close {
+  padding: 0;
+  background: none;
+  border: none;
+  color: var(--lace-color-text-muted);
+  font-size: var(--lace-font-size-2xl);
+  line-height: 1;
+  cursor: pointer;
+}
+
+.lace-error-dialog__list {
+  flex: 1 1 auto;
+  min-height: 0;
+  padding: var(--lace-space-3) var(--lace-space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--lace-space-2);
+  overflow-y: auto;
+}
+
+.lace-error-dialog__item {
+  padding: var(--lace-space-2) var(--lace-space-3);
+  background: var(--lace-color-red-900);
+  border: 1px solid var(--lace-color-red-alpha-20);
+  border-radius: var(--lace-radius-md);
+}
+
+.lace-error-dialog__item-message {
+  margin-bottom: var(--lace-space-1);
+  color: var(--lace-color-text-danger-soft);
+  font-size: var(--lace-font-size-md);
+}
+
+.lace-error-dialog__file-link {
+  display: block;
+  margin-bottom: var(--lace-space-1);
+  padding: 0;
+  background: none;
+  border: none;
+  color: var(--lace-color-text-muted);
+  font-size: var(--lace-font-size-xs);
+  text-align: left;
+  text-decoration: underline;
+  text-decoration-color: rgba(136, 136, 136, 0.4);
+  cursor: pointer;
+}
+
+.lace-error-dialog__node-link {
+  padding: 2px var(--lace-space-2);
+  background: var(--lace-color-accent-alpha-subtle);
+  border: 1px solid var(--lace-color-accent-alpha-medium);
+  border-radius: var(--lace-radius-sm);
+  color: var(--lace-color-accent);
+  font-size: var(--lace-font-size-xs);
+  cursor: pointer;
+}

--- a/packages/canvas/src/components/ValidationErrorBanner.tsx
+++ b/packages/canvas/src/components/ValidationErrorBanner.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import type { Diagnostic } from '../types/render';
+import './ValidationErrorBanner.css';
 
 // ── ValidationErrorDialog ──────────────────────────────────────────────────
 
@@ -20,82 +21,48 @@ function ValidationErrorDialog({
 }: DialogProps) {
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center"
-      style={{ background: 'rgba(0,0,0,0.6)' }}
+      className="lace-error-dialog-backdrop"
       onClick={onClose}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') onClose();
+      }}
+      role="presentation"
     >
       <div
-        className="relative rounded-lg shadow-2xl"
-        style={{
-          background: '#1a1a1a',
-          border: '1px solid rgba(229,72,77,0.35)',
-          width: 520,
-          maxHeight: '70vh',
-          display: 'flex',
-          flexDirection: 'column',
-        }}
+        className="lace-error-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="lace-error-dialog-title"
         onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
       >
-        {/* Header */}
-        <div
-          className="flex items-center justify-between px-4 py-3"
-          style={{ borderBottom: '1px solid rgba(229,72,77,0.2)' }}
-        >
-          <span style={{ color: '#f87171', fontSize: 13, fontWeight: 600 }}>
+        <header className="lace-error-dialog__header">
+          <h2 id="lace-error-dialog-title" className="lace-error-dialog__title">
             Terraform Validation Errors ({diagnostics.length})
-          </span>
+          </h2>
           <button
+            type="button"
+            className="lace-error-dialog__close"
             onClick={onClose}
-            style={{
-              color: '#888',
-              background: 'none',
-              border: 'none',
-              cursor: 'pointer',
-              fontSize: 16,
-              lineHeight: 1,
-            }}
             title="Close"
+            aria-label="Close"
           >
             ×
           </button>
-        </div>
-
-        {/* Error list */}
-        <div
-          className="overflow-y-auto flex-1 px-4 py-3"
-          style={{ gap: 10, display: 'flex', flexDirection: 'column' }}
-        >
+        </header>
+        <div className="lace-error-dialog__list">
           {diagnostics.map((d, i) => {
             const nodeId = extractNodeId(d, nodeIds);
             const hasFileLink = !!d.file;
             return (
-              <div
-                key={i}
-                style={{
-                  background: '#2a1414',
-                  border: '1px solid rgba(229,72,77,0.2)',
-                  borderRadius: 6,
-                  padding: '8px 10px',
-                }}
-              >
-                <div style={{ color: '#f87171', fontSize: 12, marginBottom: 4 }}>{d.message}</div>
+              <div key={`${d.message}-${i}`} className="lace-error-dialog__item">
+                <div className="lace-error-dialog__item-message">{d.message}</div>
                 {hasFileLink && (
                   <button
+                    type="button"
+                    className="lace-error-dialog__file-link"
                     onClick={() => onOpenFile(d.file!, d.line, d.column)}
                     title="Open file in editor"
-                    style={{
-                      display: 'block',
-                      color: '#888',
-                      fontSize: 10,
-                      marginBottom: nodeId ? 6 : 0,
-                      background: 'none',
-                      border: 'none',
-                      padding: 0,
-                      cursor: 'pointer',
-                      textAlign: 'left',
-                      textDecoration: 'underline',
-                      textDecorationColor: 'rgba(136,136,136,0.4)',
-                    }}
                   >
                     {d.file}
                     {d.line != null && `:${d.line}`}
@@ -104,16 +71,9 @@ function ValidationErrorDialog({
                 )}
                 {nodeId && (
                   <button
+                    type="button"
+                    className="lace-error-dialog__node-link"
                     onClick={() => onGoToNode(nodeId)}
-                    style={{
-                      fontSize: 10,
-                      color: '#CEFE65',
-                      background: 'rgba(206,254,101,0.08)',
-                      border: '1px solid rgba(206,254,101,0.25)',
-                      borderRadius: 4,
-                      padding: '2px 8px',
-                      cursor: 'pointer',
-                    }}
                   >
                     View node
                   </button>
@@ -150,52 +110,36 @@ export function ValidationErrorBanner({
 
   return (
     <>
-      {/* Persistent banner — top-right, below the ActionBar. Matches Toast's
-          60px/16px offset so banner and toast visually align. */}
-      <div
-        className="absolute top-[60px] right-4 z-20 flex items-center gap-2 px-3 py-1.5 rounded-md text-xs shadow-[0_2px_6px_rgba(0,0,0,0.3)] border"
-        style={{
-          background: '#3a1518',
-          color: '#f87171',
-          borderColor: 'rgba(248,113,113,0.3)',
-        }}
-      >
-        <svg width="13" height="13" viewBox="0 0 16 16" fill="#f87171" style={{ flexShrink: 0 }}>
+      <div className="lace-error-banner" role="status">
+        <svg
+          className="lace-error-banner__icon"
+          width="13"
+          height="13"
+          viewBox="0 0 16 16"
+          fill="currentColor"
+          aria-hidden="true"
+        >
           <path d="M8 1a7 7 0 1 0 0 14A7 7 0 0 0 8 1zm0 3.5c.28 0 .5.22.5.5v3a.5.5 0 0 1-1 0V5c0-.28.22-.5.5-.5zm0 6a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5z" />
         </svg>
-        <span>Terraform validation failed</span>
+        <span className="lace-error-banner__message">Terraform validation failed</span>
         <button
+          type="button"
+          className="lace-error-banner__view-details"
           onClick={() => setDialogOpen(true)}
-          style={{
-            color: '#f87171',
-            background: 'rgba(248,113,113,0.12)',
-            border: '1px solid rgba(248,113,113,0.3)',
-            borderRadius: 4,
-            padding: '1px 7px',
-            cursor: 'pointer',
-            fontSize: 11,
-          }}
         >
           View details
         </button>
         <button
+          type="button"
+          className="lace-error-banner__dismiss"
           onClick={onDismiss}
-          style={{
-            color: '#888',
-            background: 'none',
-            border: 'none',
-            cursor: 'pointer',
-            fontSize: 14,
-            lineHeight: 1,
-            padding: '0 2px',
-          }}
           title="Dismiss"
+          aria-label="Dismiss"
         >
           ×
         </button>
       </div>
 
-      {/* Dialog — only mounts when opened */}
       {dialogOpen && (
         <ValidationErrorDialog
           diagnostics={diagnostics}

--- a/packages/canvas/src/engine.ts
+++ b/packages/canvas/src/engine.ts
@@ -18,9 +18,14 @@ import type {
  */
 export type EngineEvent =
   | { type: 'stateUpdated'; view: CanvasView; viewportIntent?: ViewportIntent }
-  | { type: 'generateProgress'; phase: GeneratePhase }
-  | { type: 'generateSuccess'; files?: string[] }
-  | { type: 'generateError'; message: string; diagnostics?: Diagnostic[] };
+  | { type: 'generateProgress'; phase: GeneratePhase; toastDurationMs?: number }
+  | { type: 'generateSuccess'; files?: string[]; toastDurationMs?: number }
+  | {
+      type: 'generateError';
+      message: string;
+      diagnostics?: Diagnostic[];
+      toastDurationMs?: number;
+    };
 
 export type EngineEventListener = (event: EngineEvent) => void;
 

--- a/packages/canvas/src/hooks/useGenerationStatus.ts
+++ b/packages/canvas/src/hooks/useGenerationStatus.ts
@@ -21,13 +21,13 @@ export function useGenerationStatus(showToast: ShowToastFn) {
         case 'generateProgress':
           setGenerating(true);
           setValidationErrors([]);
-          showToast(PHASE_LABELS[event.phase], 'progress');
+          showToast(PHASE_LABELS[event.phase], 'progress', event.toastDurationMs);
           return;
         case 'generateSuccess':
           setGenerating(false);
           setValidationErrors([]);
           setErrorBannerDismissed(false);
-          showToast('Successfully generated', 'success');
+          showToast('Successfully generated', 'success', event.toastDurationMs);
           return;
         case 'generateError': {
           setGenerating(false);
@@ -35,9 +35,9 @@ export function useGenerationStatus(showToast: ShowToastFn) {
           setValidationErrors(diags);
           setErrorBannerDismissed(false);
           if (diags.length > 0) {
-            showToast(`Validation: ${diags.length} error(s)`, 'error');
+            showToast(`Validation: ${diags.length} error(s)`, 'error', event.toastDurationMs);
           } else {
-            showToast(`Generate error: ${event.message}`, 'error');
+            showToast(`Generate error: ${event.message}`, 'error', event.toastDurationMs);
           }
           return;
         }

--- a/packages/canvas/src/hooks/useToast.ts
+++ b/packages/canvas/src/hooks/useToast.ts
@@ -5,6 +5,19 @@ export type ToastState = { message: string; type: 'progress' | 'success' | 'erro
 const TOAST_BRIEF = 1500;
 const TOAST_INFO = 3000;
 
+/**
+ * `duration` in ms controls auto-dismiss:
+ *   - omitted → default per type (brief for success, longer for error)
+ *   - finite number → explicit ms before the toast clears itself
+ *   - `Infinity` → pinned; never auto-dismisses. Used by scene stories
+ *     to hold a state for Chromatic snapshot.
+ *   - `0` → effectively skipped; the setTimeout runs on the next tick
+ *     and clears the toast before it's visible. Scene stories emit
+ *     this when they want the side-effects of an event (banner state,
+ *     spinner state) without the transient toast.
+ *
+ * `progress`-type toasts never auto-dismiss regardless of `duration`.
+ */
 export type ShowToastFn = (
   message: string,
   type: 'progress' | 'success' | 'error',
@@ -16,10 +29,10 @@ export function useToast() {
 
   const showToast: ShowToastFn = useCallback((message, type, duration) => {
     setToast({ message, type });
-    if (type !== 'progress') {
-      const ms = duration ?? (type === 'error' ? TOAST_INFO : TOAST_BRIEF);
-      setTimeout(() => setToast(null), ms);
-    }
+    if (type === 'progress') return;
+    if (duration === Number.POSITIVE_INFINITY) return;
+    const ms = duration ?? (type === 'error' ? TOAST_INFO : TOAST_BRIEF);
+    setTimeout(() => setToast(null), ms);
   }, []);
 
   const clearToast = useCallback(() => setToast(null), []);

--- a/packages/canvas/src/index.css
+++ b/packages/canvas/src/index.css
@@ -1,134 +1,18 @@
-/* ── Lace brand tokens ──
- * Green Yellow:   #CEFE65  (primary accent)
- * Gunmetal:       #153238  (dark teal)
- * Night:          #161616  (background)
- * Non Photo Blue: #95E7FF  (secondary)
- * Bright Grey:    #ECEFED  (secondary)
- * Font:           Instrument Sans
- */
-
-/* ── Layer ordering ──
- * Tailwind v4 declares: @layer theme, base, components, utilities
- * Preflight resets live in @layer base.
- * ReactFlow styles go in @layer components → beats Preflight.
- * Our overrides below are unlayered → highest cascade priority.
- * No !important needed — unlayered rules beat all @layer rules.
+/*
+ * Canvas webview entry stylesheet.
+ *
+ * Deliberately thin — just the global stylesheets every canvas build
+ * needs. Component-specific styles live *with* the components
+ * (Canvas.css, composite/*.css, primitive CSS in @lace/ui). This keeps
+ * the Storybook build and the VS Code webview build visually
+ * identical: both load these three globals plus whatever CSS each
+ * rendered component imports.
+ *
+ * Layer ordering (Tailwind v4 default): theme, base, components,
+ * utilities. xyflow's stylesheet goes into @layer components so our
+ * unlayered component-level overrides in Canvas.css beat it.
  */
 
 @import "tailwindcss";
 @import "@xyflow/react/dist/style.css" layer(components);
-
-/* ── Pin handles (Blender/Fusion-style) ──
- * One handle per input variable and per output. Always visible so wiring
- * is unambiguous. Colors are set inline per pin by pinColor.ts.
- */
-
-.lace-pin-handle {
-  border-radius: 50%;
-  opacity: 0.9;
-  transition:
-    opacity 0.15s ease,
-    transform 0.1s ease;
-}
-
-.lace-pin-handle:hover {
-  opacity: 1;
-  transform: scale(1.25);
-}
-
-.react-flow__handle.lace-pin-handle.connectingfrom,
-.react-flow__handle.lace-pin-handle.connectingto {
-  opacity: 1;
-  transform: scale(1.35);
-}
-
-/* ── Controls ──
- * Bottom-left corner offsets live on the Controls component's `style`
- * prop in Canvas.tsx (alongside MiniMap's stack offset), so the layout
- * works identically in the webview and in Storybook — Storybook doesn't
- * import this stylesheet.
- */
-
-.react-flow__controls {
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
-  border-radius: 6px;
-  overflow: hidden;
-  border: 1px solid rgba(206, 254, 101, 0.15);
-}
-
-.react-flow__controls-button {
-  background: #153238;
-  border: none;
-  border-bottom: 1px solid rgba(206, 254, 101, 0.1);
-  width: 28px;
-  height: 28px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  padding: 5px;
-}
-
-.react-flow__controls-button:hover {
-  background: #1a3f47;
-}
-
-.react-flow__controls-button:last-child {
-  border-bottom: none;
-}
-
-.react-flow__controls-button svg {
-  fill: #cefe65;
-  width: 13px;
-  height: 13px;
-  max-width: 13px;
-  max-height: 13px;
-}
-
-.react-flow__controls-button:hover svg {
-  fill: #e0ff8a;
-}
-
-/* ── MiniMap ── */
-
-.react-flow__minimap {
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
-  border-radius: 6px;
-  overflow: hidden;
-  border: 1px solid rgba(206, 254, 101, 0.15);
-}
-
-/* ── Edges ──
- * Default edges use the brand green. Selected edges get a brighter
- * stroke + glow so the user can see what will be deleted on keypress.
- */
-
-.react-flow__edge path {
-  stroke: #cefe65;
-  stroke-width: 1.5;
-  transition:
-    stroke 0.15s ease,
-    stroke-width 0.15s ease,
-    filter 0.15s ease;
-}
-
-.react-flow__edge.selected path {
-  stroke: #e0ff8a;
-  stroke-width: 2.5;
-  filter: drop-shadow(0 0 4px rgba(206, 254, 101, 0.6));
-}
-
-.react-flow__edge:hover path {
-  stroke: #e0ff8a;
-  stroke-width: 2;
-}
-
-/* ── Slide panel ── */
-
-.slide-panel {
-  position: absolute;
-  right: 0;
-  top: 0;
-  height: 100%;
-  transition: transform 200ms ease-out;
-}
+@import "@lace/design-tokens/tokens.css";

--- a/packages/design-tokens/tokens.css
+++ b/packages/design-tokens/tokens.css
@@ -1,154 +1,391 @@
 /*
  * Lace Design Tokens
- * Single source of truth for colors, spacing, and visual constants.
+ * ===================
+ *
+ * Three-tier architecture (Primitive → Semantic → Component).
+ * Consumers should reference the *highest* layer that expresses intent:
+ *   - Composites reach for semantic (`--lace-color-text`, `--lace-space-3`)
+ *   - Component styles reach for component tokens (`--lace-btn-primary-bg`)
+ *   - Primitives are rarely referenced directly — they exist so the
+ *     semantic + component layers can all swap with one edit.
+ *
  * Import via: @import '@lace/design-tokens/tokens.css';
  *
- * These map to Tailwind's @theme directive in consuming packages,
- * or can be used directly as var(--lace-*).
- *
- * Rule for new code: canvas + chat-sidebar + @lace/ui components
- * must reference colors through var(--lace-*). No raw hex literals,
- * no inline Tailwind arbitrary-value classes like bg-[#1f6feb].
- * If a color isn't in this file, add a token here first.
+ * Rule for new code: no raw hex literals, no raw px values for spacing,
+ * font-size, shadow, or radius. If a token doesn't exist for your use
+ * case, add it here first — don't bypass the system.
  */
 
-:root {
-  /* ── Brand ── */
-  --lace-green: #cefe65;
-  --lace-green-bright: #e0ff8a;
-  --lace-gunmetal: #153238;
-  --lace-gunmetal-light: #1a3f47;
-  --lace-night: #161616;
-  --lace-cyan: #95e7ff;
-  --lace-grey: #ecefed;
+/* ══════════════════════════════════════════════════════════════════════
+ * TIER 1 — PRIMITIVES
+ *
+ * Raw values. Named descriptively (color/number), never by usage. These
+ * are the only tokens allowed to contain hex / rgba / px values.
+ * ══════════════════════════════════════════════════════════════════════ */
 
-  /* ── UI: Interactive ── */
-  --lace-btn-primary: #1f6feb;
-  --lace-btn-primary-dim: #1a4d8f;
+:root {
+  /* ── Palette: brand ── */
+  --lace-color-green-300: #e0ff8a;
+  --lace-color-green-500: #cefe65;
+  --lace-color-green-700: #5e8a1a;
+  --lace-color-cyan-500: #95e7ff;
+  --lace-color-cyan-700: #2c9db9;
+
+  /* ── Palette: neutral ── */
+  --lace-color-neutral-100: #ecefed;
+  --lace-color-neutral-200: #e6e6e6;
+  --lace-color-neutral-300: #cccccc;
+  --lace-color-neutral-400: #9ca3af;
+  --lace-color-neutral-500: #999999;
+  --lace-color-neutral-600: #555555;
+  --lace-color-neutral-700: #3c3c3c;
+  --lace-color-neutral-750: #333333;
+  --lace-color-neutral-800: #252526;
+  --lace-color-neutral-850: #1e1e1e;
+  --lace-color-neutral-900: #161616;
+  --lace-color-neutral-950: #0f0f0f;
+  --lace-color-neutral-black: #000000;
+
+  /* ── Palette: semantic accents ── */
+  --lace-color-teal-700: #153238;
+  --lace-color-teal-600: #1a3f47;
+  --lace-color-blue-500: #1f6feb;
+  --lace-color-blue-700: #1a4d8f;
+  --lace-color-blue-accent: #4fc1ff;
+  --lace-color-red-400: #f87171;
+  --lace-color-red-500: #e5484d;
+  --lace-color-red-700: #6e2b2b;
+  --lace-color-red-800: #3a1518;
+  --lace-color-red-900: #2a1414;
+  --lace-color-green-accent-500: #2ea043;
+  --lace-color-green-accent-600: #3ab550;
+  --lace-color-green-accent-700: #1a7f37;
+  --lace-color-amber-400: #f5a623;
+  --lace-color-amber-600: #8a5a10;
+  --lace-color-purple-400: #b084f0;
+  --lace-color-purple-700: #5c3e9a;
+  --lace-color-pink-400: #f288c6;
+  --lace-color-pink-700: #8a2e5c;
+  --lace-color-orange-400: #ff8a4c;
+  --lace-color-orange-700: #8a3a10;
+  --lace-color-tag-blue-bg: #0b1f3a;
+  --lace-color-tag-blue-border: #2b4a7a;
+  --lace-color-tag-blue-text: #9ecbff;
+
+  /* ── Palette: alpha variants ── */
+  --lace-color-green-alpha-10: rgba(206, 254, 101, 0.1);
+  --lace-color-green-alpha-15: rgba(206, 254, 101, 0.15);
+  --lace-color-green-alpha-18: rgba(206, 254, 101, 0.18);
+  --lace-color-green-alpha-20: rgba(206, 254, 101, 0.2);
+  --lace-color-green-alpha-60: rgba(206, 254, 101, 0.6);
+  --lace-color-red-alpha-12: rgba(248, 113, 113, 0.12);
+  --lace-color-red-alpha-20: rgba(229, 72, 77, 0.2);
+  --lace-color-red-alpha-25: rgba(229, 72, 77, 0.25);
+  --lace-color-red-alpha-30: rgba(248, 113, 113, 0.3);
+  --lace-color-red-alpha-35: rgba(229, 72, 77, 0.35);
+  --lace-color-green-accent-alpha-12: rgba(46, 160, 67, 0.12);
+  --lace-color-green-accent-alpha-15: rgba(46, 160, 67, 0.15);
+  --lace-color-green-accent-alpha-35: rgba(46, 160, 67, 0.35);
+  --lace-color-white-alpha-40: rgba(255, 255, 255, 0.4);
+  --lace-color-black-alpha-30: rgba(0, 0, 0, 0.3);
+  --lace-color-black-alpha-35: rgba(0, 0, 0, 0.35);
+  --lace-color-black-alpha-40: rgba(0, 0, 0, 0.4);
+  --lace-color-black-alpha-50: rgba(0, 0, 0, 0.5);
+  --lace-color-black-alpha-60: rgba(0, 0, 0, 0.6);
+  --lace-color-blue-alpha-30: rgba(59, 130, 246, 0.3);
+
+  /* ── Scale: spacing (4px base) ── */
+  --lace-space-0: 0;
+  --lace-space-1: 4px;
+  --lace-space-2: 8px;
+  --lace-space-3: 12px;
+  --lace-space-4: 16px;
+  --lace-space-5: 24px;
+  --lace-space-6: 32px;
+  --lace-space-7: 48px;
+
+  /* ── Scale: font size ── */
+  --lace-font-size-xs: 10px;
+  --lace-font-size-sm: 11px;
+  --lace-font-size-md: 12px;
+  --lace-font-size-lg: 13px;
+  --lace-font-size-xl: 14px;
+  --lace-font-size-2xl: 16px;
+
+  /* ── Scale: line height ── */
+  --lace-line-height-tight: 1.2;
+  --lace-line-height-normal: 1.4;
+  --lace-line-height-relaxed: 1.6;
+
+  /* ── Scale: font weight ── */
+  --lace-font-weight-regular: 400;
+  --lace-font-weight-medium: 500;
+  --lace-font-weight-semibold: 600;
+  --lace-font-weight-bold: 700;
+
+  /* ── Font family ── */
+  --lace-font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  --lace-font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+
+  /* ── Scale: radius ── */
+  --lace-radius-sm: 4px;
+  --lace-radius-md: 6px;
+  --lace-radius-lg: 8px;
+  --lace-radius-pill: 999px;
+
+  /* ── Scale: shadow (elevation) ── */
+  --lace-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.25);
+  --lace-shadow-md: 0 2px 8px rgba(0, 0, 0, 0.35);
+  --lace-shadow-lg: 0 4px 12px rgba(0, 0, 0, 0.5);
+  --lace-shadow-xl: 0 12px 40px rgba(0, 0, 0, 0.5);
+
+  /* ── Scale: z-index ── */
+  --lace-z-canvas: 0;
+  --lace-z-chrome: 10; /* action bar, toast, banner */
+  --lace-z-scrim: 40; /* context-menu dismiss overlay */
+  --lace-z-overlay: 50; /* context menu, modal */
+  --lace-z-tooltip: 60;
+
+  /* ── Motion ── */
+  --lace-duration-fast: 120ms;
+  --lace-duration-medium: 200ms;
+  --lace-duration-slow: 300ms;
+  --lace-easing-standard: ease;
+  --lace-easing-out: ease-out;
+}
+
+/* ══════════════════════════════════════════════════════════════════════
+ * TIER 2 — SEMANTIC
+ *
+ * Use-case-named tokens that alias primitives. Composites should prefer
+ * these over primitives so a future palette change re-themes everything
+ * with one edit.
+ * ══════════════════════════════════════════════════════════════════════ */
+
+:root {
+  /* ── Surface (background layers) ── */
+  --lace-color-bg-canvas: var(--lace-color-neutral-900);
+  --lace-color-bg-surface: var(--lace-color-neutral-850);
+  --lace-color-bg-surface-alt: var(--lace-color-neutral-800);
+  --lace-color-bg-input: var(--lace-color-neutral-950);
+  --lace-color-bg-context-menu: #1a1a1a;
+
+  /* ── Border ── */
+  --lace-color-border-default: var(--lace-color-neutral-750);
+  --lace-color-border-subtle: var(--lace-color-neutral-700);
+  --lace-color-border-input: var(--lace-color-neutral-600);
+  --lace-color-border-input-hover: #888888;
+
+  /* ── Text ── */
+  --lace-color-text-primary: var(--lace-color-neutral-100);
+  --lace-color-text-label: var(--lace-color-neutral-200);
+  --lace-color-text-muted: var(--lace-color-neutral-500);
+  --lace-color-text-description: var(--lace-color-neutral-400);
+  --lace-color-text-accent: var(--lace-color-green-500);
+  --lace-color-text-link: var(--lace-color-blue-500);
+  --lace-color-text-danger: var(--lace-color-red-500);
+  --lace-color-text-danger-soft: var(--lace-color-red-400);
+
+  /* ── Accent ── */
+  --lace-color-accent: var(--lace-color-green-500);
+  --lace-color-accent-alpha-subtle: var(--lace-color-green-alpha-10);
+  --lace-color-accent-alpha-medium: var(--lace-color-green-alpha-20);
+  --lace-color-accent-strong: var(--lace-color-green-bright, var(--lace-color-green-300));
+
+  /* ── Status ── */
+  --lace-color-success: var(--lace-color-green-accent-500);
+  --lace-color-success-hover: var(--lace-color-green-accent-600);
+  --lace-color-success-strong: var(--lace-color-green-accent-700);
+  --lace-color-danger: var(--lace-color-red-500);
+  --lace-color-danger-bg-soft: var(--lace-color-red-alpha-12);
+  --lace-color-warning-bg: #3b2507;
+  --lace-color-warning-fg: #f0a030;
+
+  /* ── Focus ring ── */
+  --lace-color-focus-ring: var(--lace-color-accent);
+}
+
+/* ══════════════════════════════════════════════════════════════════════
+ * TIER 3 — COMPONENT
+ *
+ * Specific-to-component tokens. Retained names match what composites
+ * reference today so the migration is additive. New components should
+ * prefer semantic tokens unless they need component-specific colors.
+ * ══════════════════════════════════════════════════════════════════════ */
+
+:root {
+  /* ── Brand aliases (legacy — prefer semantic) ── */
+  --lace-green: var(--lace-color-green-500);
+  --lace-green-bright: var(--lace-color-green-300);
+  --lace-gunmetal: var(--lace-color-teal-700);
+  --lace-gunmetal-light: var(--lace-color-teal-600);
+  --lace-night: var(--lace-color-neutral-900);
+  --lace-cyan: var(--lace-color-cyan-500);
+  --lace-grey: var(--lace-color-neutral-100);
+
+  /* ── Surface aliases (legacy) ── */
+  --lace-bg-surface: var(--lace-color-bg-surface);
+  --lace-bg-surface-alt: var(--lace-color-bg-surface-alt);
+  --lace-bg-input: var(--lace-color-bg-input);
+  --lace-bg-context-menu: var(--lace-color-bg-context-menu);
+  --lace-border-default: var(--lace-color-border-default);
+  --lace-border-input: var(--lace-color-border-input);
+  --lace-border-input-hover: var(--lace-color-border-input-hover);
+  --lace-border-subtle: var(--lace-color-border-subtle);
+
+  /* ── Text aliases (legacy) ── */
+  --lace-text-danger: var(--lace-color-text-danger);
+  --lace-text-danger-light: var(--lace-color-text-danger-soft);
+  --lace-text-link: var(--lace-color-text-link);
+  --lace-text-muted: var(--lace-color-text-muted);
+  --lace-text-label: var(--lace-color-text-label);
+  --lace-text-description: var(--lace-color-text-description);
+
+  /* ── Alpha variants (legacy) ── */
+  --lace-green-alpha-10: var(--lace-color-green-alpha-10);
+  --lace-green-alpha-15: var(--lace-color-green-alpha-15);
+  --lace-green-alpha-20: var(--lace-color-green-alpha-20);
+  --lace-green-alpha-60: var(--lace-color-green-alpha-60);
+
+  /* ── Button ── */
+  --lace-btn-primary: var(--lace-color-blue-500);
+  --lace-btn-primary-dim: var(--lace-color-blue-700);
   --lace-btn-secondary-bg: #2d2d2d;
   --lace-btn-secondary-hover: #3a3a3a;
-  --lace-btn-success: #1a7f37;
-  --lace-btn-success-hover: #3ab653;
-  --lace-btn-danger-bg: #6e2b2b;
+  --lace-btn-success: var(--lace-color-green-accent-700);
+  --lace-btn-success-hover: var(--lace-color-green-accent-600);
+  --lace-btn-danger-bg: var(--lace-color-red-700);
   --lace-btn-danger-hover: #8a3535;
-  --lace-btn-ghost-hover: rgba(206, 254, 101, 0.1);
+  --lace-btn-ghost-hover: var(--lace-color-accent-alpha-subtle);
   --lace-btn-text-primary: #ffffff;
-  --lace-btn-text-disabled: rgba(255, 255, 255, 0.4);
-  --lace-icon-btn-hover: rgba(206, 254, 101, 0.1);
-  --lace-icon-btn-danger-hover: rgba(229, 72, 77, 0.15);
-  --lace-icon-btn-success-hover: rgba(46, 160, 67, 0.15);
-  --lace-text-danger: #e5484d;
-  --lace-text-danger-light: #f87171;
-  --lace-text-link: #1f6feb;
-  --lace-text-muted: #999999;
-  --lace-text-label: #e6e6e6;
-  --lace-text-description: #9ca3af;
+  --lace-btn-text-disabled: var(--lace-color-white-alpha-40);
+  --lace-icon-btn-hover: var(--lace-color-accent-alpha-subtle);
+  --lace-icon-btn-danger-hover: var(--lace-color-red-alpha-30);
+  --lace-icon-btn-success-hover: var(--lace-color-green-accent-alpha-15);
 
   /* ── Modal / Overlay ── */
-  --lace-modal-backdrop: rgba(0, 0, 0, 0.6);
-  --lace-modal-shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
+  --lace-modal-backdrop: var(--lace-color-black-alpha-60);
+  --lace-modal-shadow: var(--lace-shadow-xl);
 
   /* ── Panel ── */
-  --lace-panel-shadow: 0 2px 12px rgba(0, 0, 0, 0.35);
+  --lace-panel-shadow: 0 2px 12px var(--lace-color-black-alpha-35);
+
+  /* ── ActionBar ── */
+  --lace-action-bar-bg: rgba(30, 30, 30, 0.8);
+  --lace-action-bar-separator: #444444;
+  --lace-action-bar-shadow: var(--lace-shadow-md);
+  --lace-action-bar-generate-bg: var(--lace-color-success);
+  --lace-action-bar-generate-bg-hover: var(--lace-color-success-hover);
 
   /* ── Input ── */
-  --lace-input-bg: var(--lace-bg-input);
-  --lace-input-border: var(--lace-border-default);
-  --lace-input-border-hover: var(--lace-border-input-hover);
-  --lace-input-border-focus: var(--lace-green);
-  --lace-input-border-error: var(--lace-text-danger);
-  --lace-input-text: var(--lace-grey);
-  --lace-input-placeholder: var(--lace-text-muted);
+  --lace-input-bg: var(--lace-color-bg-input);
+  --lace-input-border: var(--lace-color-border-default);
+  --lace-input-border-hover: var(--lace-color-border-input-hover);
+  --lace-input-border-focus: var(--lace-color-focus-ring);
+  --lace-input-border-error: var(--lace-color-danger);
+  --lace-input-text: var(--lace-color-text-primary);
+  --lace-input-placeholder: var(--lace-color-text-muted);
 
   /* ── ModeToggle ── */
   --lace-mode-toggle-active-bg: var(--lace-btn-primary);
   --lace-mode-toggle-active-border: var(--lace-btn-primary);
   --lace-mode-toggle-active-text: var(--lace-btn-text-primary);
   --lace-mode-toggle-inactive-bg: transparent;
-  --lace-mode-toggle-inactive-border: var(--lace-border-input);
-  --lace-mode-toggle-inactive-text: var(--lace-text-muted);
-  --lace-mode-toggle-inactive-hover-border: var(--lace-border-input-hover);
-  --lace-mode-toggle-inactive-hover-text: var(--lace-grey);
-
-  /* ── ActionBar ── */
-  --lace-action-bar-bg: rgba(30, 30, 30, 0.8);
-  --lace-action-bar-separator: #444444;
-  --lace-action-bar-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
-  --lace-action-bar-generate-bg: var(--lace-accent-green);
-  --lace-action-bar-generate-bg-hover: #3ab550;
+  --lace-mode-toggle-inactive-border: var(--lace-color-border-input);
+  --lace-mode-toggle-inactive-text: var(--lace-color-text-muted);
+  --lace-mode-toggle-inactive-hover-border: var(--lace-color-border-input-hover);
+  --lace-mode-toggle-inactive-hover-text: var(--lace-color-text-primary);
 
   /* ── Toast ── */
-  --lace-toast-success-bg: #153238;
-  --lace-toast-success-border: rgba(206, 254, 101, 0.2);
-  --lace-toast-error-bg: #3a1518;
-  --lace-toast-error-border: rgba(248, 113, 113, 0.3);
+  --lace-toast-success-bg: var(--lace-color-teal-700);
+  --lace-toast-success-border: var(--lace-color-accent-alpha-medium);
+  --lace-toast-error-bg: var(--lace-color-red-800);
+  --lace-toast-error-border: var(--lace-color-red-alpha-30);
 
   /* ── Badge ── */
-  /* Neutral: quiet count/meta pills (e.g. "(5)") */
   --lace-badge-neutral-bg: transparent;
-  --lace-badge-neutral-border: var(--lace-border-default);
-  --lace-badge-neutral-text: var(--lace-text-muted);
-  /* Info: reuse existing blue tag tokens for versions etc. */
-  --lace-badge-info-bg: var(--lace-tag-bg);
-  --lace-badge-info-border: var(--lace-tag-border);
-  --lace-badge-info-text: var(--lace-tag-text);
-  /* Success: brand green, low saturation */
-  --lace-badge-success-bg: rgba(46, 160, 67, 0.12);
-  --lace-badge-success-border: rgba(46, 160, 67, 0.35);
-  --lace-badge-success-text: var(--lace-accent-green);
-  /* Danger: red border/text on transparent, used for destructive chips */
+  --lace-badge-neutral-border: var(--lace-color-border-default);
+  --lace-badge-neutral-text: var(--lace-color-text-muted);
+  --lace-badge-info-bg: var(--lace-color-tag-blue-bg);
+  --lace-badge-info-border: var(--lace-color-tag-blue-border);
+  --lace-badge-info-text: var(--lace-color-tag-blue-text);
+  --lace-badge-success-bg: var(--lace-color-green-accent-alpha-12);
+  --lace-badge-success-border: var(--lace-color-green-accent-alpha-35);
+  --lace-badge-success-text: var(--lace-color-success);
   --lace-badge-danger-bg: transparent;
-  --lace-badge-danger-border: var(--lace-text-danger);
-  --lace-badge-danger-text: var(--lace-text-danger);
+  --lace-badge-danger-border: var(--lace-color-danger);
+  --lace-badge-danger-text: var(--lace-color-danger);
 
-  /* ── Surface ── */
-  --lace-bg-surface: #1e1e1e;
-  --lace-bg-surface-alt: #252526;
-  --lace-bg-input: #0f0f0f;
-  --lace-bg-context-menu: #1a1a1a;
-  --lace-border-default: #333333;
-  --lace-border-input: #555555;
-  --lace-border-input-hover: #888888;
-  --lace-border-subtle: #3c3c3c;
-
-  /* ── Node states ── */
-  --lace-node-error-border: #e5484d;
-  --lace-node-error-shadow: rgba(229, 72, 77, 0.3);
+  /* ── Canvas nodes (inline-styled; tokens listed for completeness) ── */
+  --lace-node-default-border: var(--lace-color-green-alpha-18);
+  --lace-node-error-border: var(--lace-color-red-500);
+  --lace-node-error-shadow-color: var(--lace-color-red-alpha-30);
   --lace-node-new-border: #3b82f6;
-  --lace-node-new-shadow: rgba(59, 130, 246, 0.3);
-  --lace-node-default-border: rgba(206, 254, 101, 0.18);
+  --lace-node-new-shadow-color: var(--lace-color-blue-alpha-30);
 
-  /* ── Pin colors (Blender-style type handles) ── */
-  --lace-pin-string-fill: #95e7ff;
-  --lace-pin-string-stroke: #2c9db9;
-  --lace-pin-number-fill: #f5a623;
-  --lace-pin-number-stroke: #8a5a10;
-  --lace-pin-bool-fill: #b084f0;
-  --lace-pin-bool-stroke: #5c3e9a;
-  --lace-pin-list-fill: #cefe65;
-  --lace-pin-list-stroke: #5e8a1a;
-  --lace-pin-map-fill: #f288c6;
-  --lace-pin-map-stroke: #8a2e5c;
-  --lace-pin-object-fill: #ff8a4c;
-  --lace-pin-object-stroke: #8a3a10;
+  /* ── Canvas pin colors (Blender-style type handles) ── */
+  --lace-pin-string-fill: var(--lace-color-cyan-500);
+  --lace-pin-string-stroke: var(--lace-color-cyan-700);
+  --lace-pin-number-fill: var(--lace-color-amber-400);
+  --lace-pin-number-stroke: var(--lace-color-amber-600);
+  --lace-pin-bool-fill: var(--lace-color-purple-400);
+  --lace-pin-bool-stroke: var(--lace-color-purple-700);
+  --lace-pin-list-fill: var(--lace-color-green-500);
+  --lace-pin-list-stroke: var(--lace-color-green-700);
+  --lace-pin-map-fill: var(--lace-color-pink-400);
+  --lace-pin-map-stroke: var(--lace-color-pink-700);
+  --lace-pin-object-fill: var(--lace-color-orange-400);
+  --lace-pin-object-stroke: var(--lace-color-orange-700);
   --lace-pin-any-fill: #9ba19e;
   --lace-pin-any-stroke: #4a4f4c;
 
-  /* ── Alpha variants (borders, glows, overlays) ── */
-  --lace-green-alpha-10: rgba(206, 254, 101, 0.1);
-  --lace-green-alpha-15: rgba(206, 254, 101, 0.15);
-  --lace-green-alpha-20: rgba(206, 254, 101, 0.2);
-  --lace-green-alpha-60: rgba(206, 254, 101, 0.6);
+  /* ── Canvas controls + minimap ── */
+  --lace-canvas-controls-bg: var(--lace-gunmetal);
+  --lace-canvas-controls-bg-hover: var(--lace-gunmetal-light);
+  --lace-canvas-controls-icon: var(--lace-color-accent);
+  --lace-canvas-controls-icon-hover: var(--lace-color-accent-strong);
+  --lace-canvas-controls-border: var(--lace-color-accent-alpha-medium);
+  --lace-canvas-minimap-bg: #111111;
+  --lace-canvas-minimap-border: var(--lace-color-border-default);
+  --lace-canvas-minimap-mask: var(--lace-color-black-alpha-60);
+  --lace-canvas-edge-stroke: var(--lace-color-accent);
+  --lace-canvas-edge-stroke-selected: var(--lace-color-accent-strong);
+  --lace-canvas-edge-stroke-width: 1.5px;
+  --lace-canvas-edge-stroke-width-selected: 2.5px;
 
   /* ── Module detail panel ── */
-  --lace-accent-blue: #4fc1ff;
-  --lace-accent-green: #2ea043;
+  --lace-accent-blue: var(--lace-color-blue-accent);
+  --lace-accent-green: var(--lace-color-success);
   --lace-code-string: #ce9178;
-  --lace-warning-bg: #3b2507;
-  --lace-warning-fg: #f0a030;
+  --lace-warning-bg: var(--lace-color-warning-bg);
+  --lace-warning-fg: var(--lace-color-warning-fg);
 
-  /* ── Tag pill (module config panel) ── */
-  --lace-tag-border: #2b4a7a;
-  --lace-tag-bg: #0b1f3a;
-  --lace-tag-text: #9ecbff;
+  /* ── Tag pill (legacy — prefer Badge primitive) ── */
+  --lace-tag-border: var(--lace-color-tag-blue-border);
+  --lace-tag-bg: var(--lace-color-tag-blue-bg);
+  --lace-tag-text: var(--lace-color-tag-blue-text);
+}
+
+/* ══════════════════════════════════════════════════════════════════════
+ * GLOBAL DEFAULTS
+ *
+ * Applied at the root so every webview / Storybook iframe picks them up
+ * without requiring each component to restate them.
+ * ══════════════════════════════════════════════════════════════════════ */
+
+html,
+body {
+  font-family: var(--lace-font-sans);
+  font-size: var(--lace-font-size-md);
+  line-height: var(--lace-line-height-normal);
+  color: var(--lace-color-text-primary);
+  background: var(--lace-color-bg-canvas);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
 }


### PR DESCRIPTION
## Root cause addressed

Canvas composites mixed three styling strategies (Tailwind arbitrary values + shared `index.css` + inline `style`). The shared stylesheet was imported by the webview entry but **not** by Storybook's `preview.css`, so Storybook rendered a divergent — often broken — version of every composite it loaded. Chromatic baselines were not accurate representations of production. White-on-white zoom controls were the visible symptom; the class of bug runs wider.

This PR is the infrastructure fix. A follow-up composite migration PR converts the remaining Tailwind users.

## What changes

**Design tokens — three-tier architecture**
- Primitive / Semantic / Component layers (Carbon / Material 3 / Primer pattern)
- Scale tokens: \`--lace-space-{0..7}\`, \`--lace-font-size-{xs..2xl}\`, \`--lace-shadow-{sm,md,lg,xl}\`, \`--lace-radius-{sm,md,lg,pill}\`, \`--lace-z-*\`, \`--lace-font-sans/mono\`, duration + easing
- Legacy token names retained as component-tier aliases (additive migration)
- Global \`html/body\` defaults at the root (font, color, background, \`box-sizing: border-box\`)

**Canvas styling**
- \`Canvas.css\` created, colocated with \`Canvas.tsx\` and imported there. Holds xyflow customisations (controls chrome, minimap border, edge stroke, pin handle transitions, slide-panel transform). Loads automatically via the React import chain in both webview and Storybook — no more divergence.
- \`packages/canvas/src/index.css\` slimmed to just the three global imports the webview entry needs
- Storybook \`preview.css\` trusts tokens.css for global defaults

**Overlay positioning / sizing**
- MiniMap downsized \`200×150 → 160×110\` (xyflow default is oversized for <50-node canvases); positioned via inline \`style\` prop using xyflow's first-class API
- Controls styled via \`Canvas.css\` — brand gunmetal buttons with green-accent icons (were white-on-white in Storybook)

**ValidationErrorBanner**
- Refactored to plain CSS + tokens (colocated \`ValidationErrorBanner.css\`). Required because the ValidationError scene story needs it to render; mirrors the ContextMenu/Toast/ActionBar pattern.

**Scene stories (new pattern)**
- \`EngineEvent.toastDurationMs\` added; \`useToast\` honors \`Infinity\` (pin) / \`0\` (skip) / finite ms.
- \`MockCanvasEngine.emit()\` is now public; \`MockFlowDecorator\` accepts an \`onReady(engine)\` hook.
- Three scenes: \`Flows/Scene/SaveSuccess\`, \`Generating\`, \`ValidationError\`. These mount the real App against the mock engine and pin it into a composition-level UI state. Catch layout regressions isolated component stories cannot.

## What stays (for the follow-up PR)

`@lace/canvas` still imports Tailwind from `index.css` because these composites still reference utility classes and arbitrary-value classes:

- `AccordionSection`
- `PanelFrame` (being replaced by `@lace/ui/Panel` in the composite PR)
- `SlidePanel`
- Config panels: `ModuleConfigPanel`, `LocalsPanel`, `ProvidersPanel`, `EnvironmentsPanel`, `TerraformConfigPanel`, `EdgeInspectorPanel`, `UnifiedSettingsPanel`
- `packages/canvas/src/styles/panel.ts` (`inputClasses`, `modeButtonBase`, etc.) — callers migrate to `@lace/ui` primitives

Once those land, the Tailwind import disappears entirely from `@lace/canvas`. Live-CLI `Flows/*` stories and Playwright flow-tests are unchanged.

## Stories new/changed

**New**
- `Flows/Scene/SaveSuccess / Default`
- `Flows/Scene/Generating / Default`
- `Flows/Scene/ValidationError / Default`

**Visually different (same story IDs)**
- Every `Flows/Mock/*` story now shows correct zoom-controls (gunmetal/green) and smaller MiniMap. Accept new baselines.

## Verified

- [x] `npx tsc --noEmit` clean
- [x] `pnpm run test:unit` — 123/123 (includes 5 MockCanvasEngine tests)
- [x] `pnpm run lint` — biome clean
- [x] Playwright MCP DOM-parity checks: MiniMap 160×110, controls bg `rgb(21,50,56)`, controls SVG fill `rgb(206,254,101)`, body font computed to `--lace-font-sans`
- [x] Each scene story renders its pinned state correctly

## References

- 3-tier token architecture: [IBM Carbon](https://carbondesignsystem.com/guidelines/color/tokens/), [Material 3 tokens](https://m3.material.io/foundations/design-tokens/overview), [Primer functional color](https://primer.style/foundations/color/overview)
- Storybook scene-stories pattern: [Writing stories for multiple components](https://storybook.js.org/docs/writing-stories/stories-for-multiple-components)
- CSS colocation convention: [Rsbuild CSS usage](https://rsbuild.dev/guide/basic/css-usage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)