### PR TITLE
feat(canvas): add read-only mode for inspection-only hosts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ deleting or renaming the canonical ones requires a note in the PR.
 
 **Composites (`Components / *`)** — at least the happy path + one "extreme" state (error, max data, or long text) that catches layout drift:
 
-- `ActionBar` — default, generating, minimap-shown, interactive-toggle
+- `ActionBar` — default, generating, minimap-shown, interactive-toggle, read-only
 - `Toast` — success, error, progress (phase variants are visually identical; one story covers them all)
 - `ContextMenu` — single-node, multi-select, group-right-click
 - `ValidationErrorBanner` — single diagnostic, multiple diagnostics (dialog state covered via Scene)
@@ -193,14 +193,14 @@ deleting or renaming the canonical ones requires a note in the PR.
 
 - `TerraformConfigPanel`, `LocalsPanel`, `ProvidersPanel`, `EnvironmentsPanel` — empty + populated each
 - `EdgeInspectorPanel` — typical (no empty state; only opens with a selected edge)
-- `ModuleConfigPanel` — loading, populated-with-required, wired-inputs
+- `ModuleConfigPanel` — loading, populated-with-required, wired-inputs, read-only
 - `UnifiedSettingsPanel` — loading, populated, empty
 
 **Flows**:
 
 - `Flows / *` — one per seed fixture (empty, iam-role, wired-stack, iam-stack, collapsed-group). `disableSnapshot: true`; Playwright exercises them against the real CLI.
 - `Flows / Mock / *` — mock twins of the live flows, Chromatic-captured.
-- `Flows / Scene / *` — canonical user moments: SaveSuccess, Generating, ValidationError, MiniMapVisible, MiniMapHidden, ConfigOpen, SettingsOpen, EdgeSelected, ContextMenuOpen, ConfirmClear.
+- `Flows / Scene / *` — canonical user moments: SaveSuccess, Generating, ValidationError, MiniMapVisible, MiniMapHidden, ConfigOpen, SettingsOpen, EdgeSelected, ContextMenuOpen, ConfirmClear, ReadOnly.
 
 New primitives, composites, or panels need their canonical entries appended to this list in the same PR that ships them.
 
@@ -228,6 +228,56 @@ Notes:
   `tests/flow/__snapshots__/seed-manifest.json` in the same PR.
 - Locally, set `LACE_CLI_REPO=../lace-cli` (or absolute path) so the
   canary can find lace-cli's `testdata/seeds/*.sha256` canaries.
+
+### Read-only mode
+
+The `@lace/canvas` `App` takes an optional `readOnly?: boolean` prop
+(default `false`) so consumers that show state without letting users
+mutate it — portal's control plane is the driving example — can mount
+the same canvas without re-implementing half of it.
+
+**Semantic contract: view manipulation vs. IR mutation.**
+
+- Allowed: pan, zoom, selection, hover/tooltip inspection, MiniMap
+  toggle + zoom controls, panel inspection (ModuleConfigPanel,
+  UnifiedSettingsPanel, EdgeInspectorPanel in inspection-only shapes),
+  drag-to-reposition (xyflow local state updates; no `syncLayout`
+  round-trip), expand/collapse groups (local override merged into the
+  view before it reaches `useGroupLogic`).
+- Blocked: delete, rename, connect, reconnect, create group, ungroup,
+  edit any input in any panel, Save (Cmd+S), Generate, Undo/Redo,
+  Clear all, copy/cut/paste, context menu.
+
+**Three-layer gating principle** — gate at the layer closest to the
+concern. No belt-and-suspenders.
+
+1. **xyflow native props** for every capability xyflow owns:
+   `nodesConnectable={!readOnly}`, `edgesReconnectable={!readOnly}`,
+   `deleteKeyCode={readOnly ? null : [...]}`. Don't re-implement at the
+   handler layer.
+2. **Conditional handler installation** for window-level listeners.
+   `CANVAS_EVENTS.SAVE` and `CANVAS_EVENTS.GENERATE` handlers, plus
+   `window.__canvasUndo` / `__canvasCopy` / `__canvasCut` /
+   `__canvasPaste`, are skipped when `readOnly`. The host may still
+   dispatch Cmd+S/Z/C/X/V — it falls through to a no-op because nothing
+   is installed. No runtime guard needed.
+3. **Render gates** for UI affordances. ActionBar renders only the
+   MiniMap toggle + Settings gear; ModuleNode / GroupNode hover-delete
+   + ungroup buttons render `null`; panel Save / Disconnect / Add /
+   Remove buttons render `null`; Input / Textarea forwards `readOnly`;
+   ModeToggle items all `disabled`.
+
+**No engine-layer guard.** The hosted backend (portal) rejects via
+authz; canvas's job is not to attempt. UI gate + conditional handler
+install = two independent defenses at the right layers.
+
+**Group collapse in read-only** is the one structural nuance. It's a
+view op that normally persists via `engine.updateGroup({collapsed})`,
+which we must not call in read-only. `CanvasContext` carries a
+`localGroupCollapseOverrides` map; `App` merges it into `view.groups`
+before rendering so `useGroupLogic` (xyflow's child-hiding + external
+pin computation) reads the effective collapsed flag from one source of
+truth.
 
 ## Critical Rules
 

--- a/packages/canvas-stories/src/decorators/mock-flow-decorator.tsx
+++ b/packages/canvas-stories/src/decorators/mock-flow-decorator.tsx
@@ -33,6 +33,12 @@ type Props = {
    * microtask after mount so subscriptions have landed.
    */
   onReady?: (engine: MockCanvasEngine) => void;
+  /**
+   * Forwards to `<App readOnly>`. Scene stories for read-only mode
+   * use this to mount the canvas with every IR-mutating affordance
+   * hidden or gated off.
+   */
+  readOnly?: boolean;
 };
 
 /**
@@ -41,7 +47,7 @@ type Props = {
  * captured by `scripts/capture-fixtures.mjs`. Stories using this decorator
  * snapshot in Chromatic's cloud without any backend.
  */
-export function MockFlowDecorator({ fixture, engineOptions, onReady }: Props) {
+export function MockFlowDecorator({ fixture, engineOptions, onReady, readOnly }: Props) {
   const engine = useMemo(
     () => new MockCanvasEngine(fixture, engineOptions),
     [fixture, engineOptions],
@@ -58,7 +64,7 @@ export function MockFlowDecorator({ fixture, engineOptions, onReady }: Props) {
 
   return (
     <div style={{ position: 'relative', width: '100%', height: '100vh' }}>
-      <App engine={engine} hostBridge={hostBridge} />
+      <App engine={engine} hostBridge={hostBridge} readOnly={readOnly} />
     </div>
   );
 }

--- a/packages/canvas-stories/src/mocks/canvas-context.tsx
+++ b/packages/canvas-stories/src/mocks/canvas-context.tsx
@@ -49,15 +49,26 @@ const noopEngine: CanvasEngine = {
 type Props = {
   children: ReactNode;
   view?: CanvasView | null;
+  readOnly?: boolean;
 };
 
-export function MockCanvasContext({ children, view = null }: Props) {
+export function MockCanvasContext({ children, view = null, readOnly = false }: Props) {
   return (
     <CanvasContext.Provider
       value={{
-        state: { view, loading: false, error: null, generation: 0 },
+        state: {
+          view,
+          loading: false,
+          error: null,
+          generation: 0,
+          viewportIntent: null,
+          viewportIntentSeq: 0,
+        },
         engine: noopEngine,
         updateView: () => {},
+        readOnly,
+        localGroupCollapseOverrides: {},
+        toggleLocalGroupCollapse: () => {},
       }}
     >
       {children}

--- a/packages/canvas-stories/src/stories/ActionBar.stories.tsx
+++ b/packages/canvas-stories/src/stories/ActionBar.stories.tsx
@@ -76,3 +76,10 @@ export const InteractiveMiniMapToggle: Story = {
     return <ActionBar {...args} showMiniMap={shown} onToggleMiniMap={() => setShown((v) => !v)} />;
   },
 };
+
+// Read-only — only MiniMap toggle + Settings gear render. Save,
+// Clear, Undo, Redo, and Generate are IR-mutating and hidden. Portal
+// and any inspection-only host mount the canvas through this shape.
+export const ReadOnly: Story = {
+  args: { readOnly: true, isGenerating: false, showMiniMap: false, onToggleMiniMap: () => {} },
+};

--- a/packages/canvas-stories/src/stories/flows/scene/ReadOnly.stories.tsx
+++ b/packages/canvas-stories/src/stories/flows/scene/ReadOnly.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { MockFlowDecorator } from '../../../decorators/mock-flow-decorator';
+import { iamStackFixture } from '../../../mocks/fixtures';
+
+// Scene — canvas mounted in read-only mode. Portal and any future
+// inspection-only host renders the canvas through this path:
+//
+// - ActionBar reduces to 2 icons (MiniMap toggle + Settings gear);
+//   Save / Clear / Undo / Redo / Generate are gone.
+// - ModuleNode hover-delete + node rename are inaccessible.
+// - GroupNode ungroup + group rename are inaccessible.
+// - Right-click menu is suppressed at the dispatch site.
+// - xyflow native props (`nodesConnectable`, `edgesReconnectable`,
+//   `deleteKeyCode`) are off.
+//
+// Drag / zoom / pan / select / expand-collapse groups still work —
+// those are view ops.
+
+const meta: Meta = {
+  title: 'Flows/Scene/ReadOnly',
+  parameters: { layout: 'fullscreen' },
+};
+export default meta;
+
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => <MockFlowDecorator fixture={iamStackFixture} readOnly />,
+};

--- a/packages/canvas-stories/src/stories/panels/ModuleConfigPanel.stories.tsx
+++ b/packages/canvas-stories/src/stories/panels/ModuleConfigPanel.stories.tsx
@@ -15,6 +15,7 @@ import { MockCanvasEngine } from '../../mocks/mock-engine';
 type StoryArgs = {
   instanceId: string;
   nodeConfig: typeof vpcNodeConfig | 'loading';
+  readOnly?: boolean;
 };
 
 const meta: Meta<StoryArgs> = {
@@ -28,22 +29,6 @@ const meta: Meta<StoryArgs> = {
       },
     },
   },
-  decorators: [
-    (Story) => (
-      <MockCanvasContext view={emptyFixture}>
-        <div
-          style={{
-            position: 'relative',
-            width: 520,
-            height: '100vh',
-            background: 'var(--lace-color-bg-canvas)',
-          }}
-        >
-          <Story />
-        </div>
-      </MockCanvasContext>
-    ),
-  ],
   render: (args) => {
     const engine = useMemo(() => {
       if (args.nodeConfig === 'loading') {
@@ -59,12 +44,23 @@ const meta: Meta<StoryArgs> = {
     }, [args.nodeConfig]);
 
     return (
-      <ModuleConfigPanel
-        instance_id={args.instanceId}
-        engine={engine}
-        onClose={() => {}}
-        onModified={() => {}}
-      />
+      <MockCanvasContext view={emptyFixture} readOnly={args.readOnly ?? false}>
+        <div
+          style={{
+            position: 'relative',
+            width: 520,
+            height: '100vh',
+            background: 'var(--lace-color-bg-canvas)',
+          }}
+        >
+          <ModuleConfigPanel
+            instance_id={args.instanceId}
+            engine={engine}
+            onClose={() => {}}
+            onModified={() => {}}
+          />
+        </div>
+      </MockCanvasContext>
     );
   },
 };
@@ -95,4 +91,12 @@ export const PopulatedRequiredAndOptional: Story = {
 export const WiredInputs: Story = {
   name: 'Wired inputs (disconnect flow)',
   args: { instanceId: 'attachment', nodeConfig: attachmentNodeConfig },
+};
+
+// Read-only — every editable affordance is gated off. Inputs carry
+// `readonly`, ModeToggle items all disabled, disconnect + Save CTA
+// hidden. Portal-mode inspection lands here.
+export const ReadOnly: Story = {
+  name: 'Read-only (inspection)',
+  args: { instanceId: 'vpc', nodeConfig: vpcNodeConfig, readOnly: true },
 };

--- a/packages/canvas/src/App.tsx
+++ b/packages/canvas/src/App.tsx
@@ -25,9 +25,15 @@ export type HostBridge = {
 type AppProps = {
   engine: CanvasEngine;
   hostBridge: HostBridge;
+  /**
+   * When true, the canvas renders in read-only mode: pan/zoom/drag/inspect
+   * still work, but every IR-mutating affordance (save, delete, rename,
+   * wire, generate) is hidden or blocked. Defaults to `false`.
+   */
+  readOnly?: boolean;
 };
 
-export default function App({ engine, hostBridge }: AppProps) {
+export default function App({ engine, hostBridge, readOnly = false }: AppProps) {
   const [state, setState] = useState<CanvasState>({
     view: null,
     loading: true,
@@ -36,6 +42,15 @@ export default function App({ engine, hostBridge }: AppProps) {
     viewportIntent: null,
     viewportIntentSeq: 0,
   });
+
+  // Read-only local collapse overrides. Untouched when readOnly=false
+  // (editable canvas persists collapse via engine.updateGroup instead).
+  const [localGroupCollapseOverrides, setLocalGroupCollapseOverrides] = useState<
+    Record<string, boolean>
+  >({});
+  const toggleLocalGroupCollapse = useCallback((groupId: string, currentCollapsed: boolean) => {
+    setLocalGroupCollapseOverrides((prev) => ({ ...prev, [groupId]: !currentCollapsed }));
+  }, []);
 
   const updateView = useCallback((view: CanvasView) => {
     setState((prev) => ({
@@ -72,9 +87,16 @@ export default function App({ engine, hostBridge }: AppProps) {
     else hostBridge.markClean();
   }, [state.view?.is_dirty, hostBridge]);
 
-  useWindowEvent(CANVAS_EVENTS.SAVE, () => engine.sessionSave(), [engine]);
+  // SAVE / GENERATE are host-dispatched mutations. In read-only we
+  // don't install listeners — so if the host accidentally dispatches
+  // them, the canvas is silent. Gating at the install site (rather
+  // than inside the handler) keeps read-only mode a structural
+  // property, not a runtime check.
+  useWindowEvent(CANVAS_EVENTS.SAVE, () => engine.sessionSave(), [engine], { enabled: !readOnly });
 
-  useWindowEvent(CANVAS_EVENTS.GENERATE, () => hostBridge.triggerGenerate(), [hostBridge]);
+  useWindowEvent(CANVAS_EVENTS.GENERATE, () => hostBridge.triggerGenerate(), [hostBridge], {
+    enabled: !readOnly,
+  });
 
   useWindowEvent(
     CANVAS_EVENTS.OPEN_FILE,
@@ -96,7 +118,16 @@ export default function App({ engine, hostBridge }: AppProps) {
 
   return (
     <ErrorBoundary>
-      <CanvasContext.Provider value={{ state, engine, updateView }}>
+      <CanvasContext.Provider
+        value={{
+          state,
+          engine,
+          updateView,
+          readOnly,
+          localGroupCollapseOverrides,
+          toggleLocalGroupCollapse,
+        }}
+      >
         <ReactFlowProvider>
           <Canvas />
         </ReactFlowProvider>

--- a/packages/canvas/src/Canvas.tsx
+++ b/packages/canvas/src/Canvas.tsx
@@ -60,6 +60,7 @@ const nodeTypes = {
 
 type CompositeEditorProps = {
   view: CanvasView;
+  readOnly: boolean;
   isGenerating: boolean;
   erroredNodeIds: Set<string>;
   newNodeIds: Set<string>;
@@ -86,6 +87,7 @@ type CompositeEditorProps = {
 
 function CompositeEditor({
   view,
+  readOnly,
   isGenerating,
   erroredNodeIds,
   newNodeIds,
@@ -278,6 +280,10 @@ function CompositeEditor({
       onNodeDragStop={onNodeDragStop}
       onNodeContextMenu={(e, node) => {
         e.preventDefault();
+        // In read-only we suppress the menu entirely — every current
+        // item is a mutation. Render-gate at the dispatch source so
+        // ContextMenu itself stays dumb.
+        if (readOnly) return;
         const selCount = selectedIdsRef.current.length;
         window.dispatchEvent(
           new CustomEvent(CANVAS_EVENTS.CONTEXT_MENU, {
@@ -293,6 +299,7 @@ function CompositeEditor({
       }}
       onPaneContextMenu={(e) => {
         e.preventDefault();
+        if (readOnly) return;
         const selCount = selectedIdsRef.current.length;
         window.dispatchEvent(
           new CustomEvent(CANVAS_EVENTS.CONTEXT_MENU, {
@@ -310,7 +317,12 @@ function CompositeEditor({
       connectionRadius={30}
       minZoom={0.15}
       maxZoom={2}
-      deleteKeyCode={['Backspace', 'Delete']}
+      // xyflow owns connect / reconnect / key-based delete. Drive its
+      // native props instead of re-implementing the gates at our
+      // handler layer.
+      nodesConnectable={!readOnly}
+      edgesReconnectable={!readOnly}
+      deleteKeyCode={readOnly ? null : ['Backspace', 'Delete']}
       fitView={false}
       proOptions={{ hideAttribution: true }}
       style={{ background: 'var(--lace-color-bg-canvas)' }}
@@ -337,6 +349,7 @@ function CompositeEditor({
       ) : null}
       <Controls position="bottom-right" showInteractive={false} style={{ bottom: 20, right: 20 }} />
       <ActionBar
+        readOnly={readOnly}
         isGenerating={isGenerating}
         onSave={onSave}
         onUndo={onUndo}
@@ -365,7 +378,7 @@ function CompositeEditor({
 // ══════════════════════════════════════════════════════════════════════
 
 export default function Canvas() {
-  const { state, engine, updateView } = useCanvas();
+  const { state, engine, updateView, readOnly, localGroupCollapseOverrides } = useCanvas();
 
   // Ref to always read the latest view (avoids stale closures in async callbacks)
   const viewRef = useRef(state.view);
@@ -423,6 +436,7 @@ export default function Canvas() {
     useCallback((ids: string[]) => selectNodesRef.current?.(ids), []),
     useCallback(() => contextMenu?.nodeId ?? null, [contextMenu]),
     dismissContextMenu,
+    readOnly,
   );
 
   // ── Listen for openNodeConfig events from ModuleNode ──
@@ -461,20 +475,30 @@ export default function Canvas() {
   }, []);
 
   // ── Expose undo globally for HTML-level Cmd+Z listener ──
+  // In read-only we skip the install: the host may still dispatch
+  // Cmd+Z (VS Code webview routes it), but `window.__canvasUndo` is
+  // undefined, so the host-side handler is a no-op. No runtime guard
+  // needed in the hook itself.
   useEffect(() => {
+    if (readOnly) return;
     window.__canvasUndo = onUndo;
     return () => {
       window.__canvasUndo = undefined;
     };
-  }, [onUndo]);
+  }, [onUndo, readOnly]);
 
   // ── Event: drag stop → sync layout to engine ──
+  // Drag is a view op and remains enabled in read-only. We just
+  // don't persist — xyflow's local `rfNodes` state already has the
+  // new coordinates, so the move is visible until the next view
+  // refresh. xyflow has no "drag but don't fire onNodeDragStop" prop,
+  // so this is the right layer for the gate.
   const onDragStop = useCallback(
     async (positions: Record<string, { x: number; y: number }>) => {
-      if (!engine) return;
+      if (!engine || readOnly) return;
       await engine.syncLayout(positions);
     },
-    [engine],
+    [engine, readOnly],
   );
 
   // ── Event: new connection ──
@@ -622,7 +646,22 @@ export default function Canvas() {
     return <ErrorState message="Engine not available." />;
   }
 
-  const view = state.view;
+  // In read-only, merge local collapse overrides into the view before
+  // handing it to CompositeEditor. useGroupLogic reads `group.collapsed`
+  // as the authoritative source, so overriding it here is the single
+  // seam that makes collapse-as-view-op work end-to-end (chevron icon,
+  // child hiding, external pin computation, edge remapping).
+  const view: CanvasView =
+    readOnly && Object.keys(localGroupCollapseOverrides).length > 0
+      ? {
+          ...state.view,
+          groups: state.view.groups.map((g) =>
+            g.id in localGroupCollapseOverrides
+              ? { ...g, collapsed: localGroupCollapseOverrides[g.id] }
+              : g,
+          ),
+        }
+      : state.view;
 
   // ── Render ──
   // Inline layout instead of Tailwind utilities so this works in Storybook
@@ -662,6 +701,7 @@ export default function Canvas() {
       <div style={{ position: 'relative', flex: '1 1 auto', minHeight: 0 }}>
         <CompositeEditor
           view={view}
+          readOnly={readOnly}
           isGenerating={generating}
           erroredNodeIds={erroredNodeIds}
           newNodeIds={newNodeIds}

--- a/packages/canvas/src/__tests__/useClipboard.test.ts
+++ b/packages/canvas/src/__tests__/useClipboard.test.ts
@@ -35,6 +35,7 @@ describe('useClipboard', () => {
         selectNodes,
         () => null,
         dismissContextMenu,
+        false,
       ),
     );
 
@@ -57,6 +58,7 @@ describe('useClipboard', () => {
         selectNodes,
         () => null,
         dismissContextMenu,
+        false,
       ),
     );
 
@@ -81,6 +83,7 @@ describe('useClipboard', () => {
         selectNodes,
         () => null,
         dismissContextMenu,
+        false,
       ),
     );
 
@@ -113,6 +116,7 @@ describe('useClipboard', () => {
         selectNodes,
         () => null,
         dismissContextMenu,
+        false,
       ),
     );
 

--- a/packages/canvas/src/__tests__/useGenerationStatus.test.ts
+++ b/packages/canvas/src/__tests__/useGenerationStatus.test.ts
@@ -37,7 +37,16 @@ function wrapper(engine: CanvasEngine) {
   return ({ children }: { children: React.ReactNode }) =>
     React.createElement(
       CanvasContext.Provider,
-      { value: { state, engine, updateView: () => {} } },
+      {
+        value: {
+          state,
+          engine,
+          updateView: () => {},
+          readOnly: false,
+          localGroupCollapseOverrides: {},
+          toggleLocalGroupCollapse: () => {},
+        },
+      },
       children,
     );
 }

--- a/packages/canvas/src/components/ActionBar.tsx
+++ b/packages/canvas/src/components/ActionBar.tsx
@@ -2,6 +2,13 @@ import { Panel } from '@xyflow/react';
 import './ActionBar.css';
 
 type ActionBarProps = {
+  /**
+   * When true, only the MiniMap toggle + Settings gear render. Save,
+   * Clear, Undo, Redo, and Generate are IR-mutating and hidden; the
+   * Settings gear is kept because the settings panel has its own
+   * read-only flow for inspection. Defaults to `false`.
+   */
+  readOnly?: boolean;
   isGenerating?: boolean;
   onSave: () => void;
   onUndo: () => void;
@@ -68,6 +75,7 @@ const SettingsIcon = () => (
 );
 
 export default function ActionBar({
+  readOnly = false,
   isGenerating,
   onSave,
   onUndo,
@@ -81,55 +89,59 @@ export default function ActionBar({
   return (
     <Panel position="top-right">
       <div className="lace-action-bar">
-        <button
-          type="button"
-          className="lace-action-bar__icon-btn"
-          onClick={onSave}
-          title="Save (Cmd+S)"
-          aria-label="Save"
-        >
-          <SaveIcon />
-        </button>
-        <button
-          type="button"
-          className="lace-action-bar__icon-btn"
-          onClick={onClearGraph}
-          title="Clear all modules"
-          aria-label="Clear all"
-        >
-          <TrashIcon />
-        </button>
-        <button
-          type="button"
-          className="lace-action-bar__icon-btn"
-          onClick={onUndo}
-          title="Undo (Cmd+Z)"
-          aria-label="Undo"
-        >
-          <UndoIcon />
-        </button>
-        <button
-          type="button"
-          className="lace-action-bar__icon-btn"
-          onClick={onRedo}
-          title="Redo (Cmd+Shift+Z)"
-          aria-label="Redo"
-        >
-          <RedoIcon />
-        </button>
+        {!readOnly && (
+          <>
+            <button
+              type="button"
+              className="lace-action-bar__icon-btn"
+              onClick={onSave}
+              title="Save (Cmd+S)"
+              aria-label="Save"
+            >
+              <SaveIcon />
+            </button>
+            <button
+              type="button"
+              className="lace-action-bar__icon-btn"
+              onClick={onClearGraph}
+              title="Clear all modules"
+              aria-label="Clear all"
+            >
+              <TrashIcon />
+            </button>
+            <button
+              type="button"
+              className="lace-action-bar__icon-btn"
+              onClick={onUndo}
+              title="Undo (Cmd+Z)"
+              aria-label="Undo"
+            >
+              <UndoIcon />
+            </button>
+            <button
+              type="button"
+              className="lace-action-bar__icon-btn"
+              onClick={onRedo}
+              title="Redo (Cmd+Shift+Z)"
+              aria-label="Redo"
+            >
+              <RedoIcon />
+            </button>
 
-        <div className="lace-action-bar__separator" aria-hidden="true" />
+            <div className="lace-action-bar__separator" aria-hidden="true" />
 
-        <button
-          type="button"
-          className="lace-action-bar__generate"
-          onClick={onGenerate}
-          disabled={isGenerating}
-          title="Generate Terraform files"
-          aria-label="Generate"
-        >
-          <GenerateIcon />
-        </button>
+            <button
+              type="button"
+              className="lace-action-bar__generate"
+              onClick={onGenerate}
+              disabled={isGenerating}
+              title="Generate Terraform files"
+              aria-label="Generate"
+            >
+              <GenerateIcon />
+            </button>
+          </>
+        )}
         <button
           type="button"
           className="lace-action-bar__icon-btn"

--- a/packages/canvas/src/components/nodes/GroupNode.tsx
+++ b/packages/canvas/src/components/nodes/GroupNode.tsx
@@ -2,7 +2,7 @@ import { Handle, type Node, type NodeProps, Position } from '@xyflow/react';
 import type React from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { CANVAS_EVENTS } from '../../events';
-import { useEngine } from '../../state/engine-context';
+import { useCanvas, useEngine } from '../../state/engine-context';
 import './GroupNode.css';
 
 // ── Data contract ──
@@ -174,10 +174,18 @@ const AggregatedPinRow: React.FC<{ pin: ExternalPin; top: number }> = ({ pin, to
 
 const GroupNode: React.FC<NodeProps<GroupNodeNode>> = ({ data }) => {
   const engine = useEngine();
+  const { readOnly, toggleLocalGroupCollapse } = useCanvas();
   const [editing, setEditing] = useState(false);
   const [editValue, setEditValue] = useState(data.label);
   const [hovered, setHovered] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  // `data.collapsed` already reflects the effective collapsed state in
+  // both modes — in read-only, App merges the local override into the
+  // groups array before it reaches useGroupLogic, so there's nothing
+  // to derive here. Keep the name local so subsequent references stay
+  // stable.
+  const collapsed = data.collapsed;
 
   useEffect(() => {
     if (editing && inputRef.current) {
@@ -188,11 +196,12 @@ const GroupNode: React.FC<NodeProps<GroupNodeNode>> = ({ data }) => {
 
   const onDoubleClick = useCallback(
     (e: React.MouseEvent) => {
+      if (readOnly) return;
       e.stopPropagation();
       setEditValue(data.label);
       setEditing(true);
     },
-    [data.label],
+    [data.label, readOnly],
   );
 
   const commitRename = useCallback(async () => {
@@ -220,6 +229,10 @@ const GroupNode: React.FC<NodeProps<GroupNodeNode>> = ({ data }) => {
   const toggleCollapsed = useCallback(
     async (e: React.MouseEvent) => {
       e.stopPropagation();
+      if (readOnly) {
+        toggleLocalGroupCollapse(data.groupId, data.collapsed);
+        return;
+      }
       try {
         const result = await engine.updateGroup(data.groupId, { collapsed: !data.collapsed });
         window.dispatchEvent(new CustomEvent(CANVAS_EVENTS.VIEW_UPDATED, { detail: result }));
@@ -227,7 +240,7 @@ const GroupNode: React.FC<NodeProps<GroupNodeNode>> = ({ data }) => {
         console.error('[GroupNode] toggle collapsed failed:', err);
       }
     },
-    [engine, data.groupId, data.collapsed],
+    [engine, data.groupId, data.collapsed, readOnly, toggleLocalGroupCollapse],
   );
 
   const onUngroup = useCallback(
@@ -246,8 +259,8 @@ const GroupNode: React.FC<NodeProps<GroupNodeNode>> = ({ data }) => {
   const headerProps = {
     label: data.label,
     memberCount: data.memberCount,
-    collapsed: data.collapsed,
-    hovered,
+    collapsed,
+    hovered: hovered && !readOnly,
     editing,
     editValue,
     inputRef,
@@ -261,7 +274,7 @@ const GroupNode: React.FC<NodeProps<GroupNodeNode>> = ({ data }) => {
 
   // ── Collapsed rendering ──
 
-  if (data.collapsed) {
+  if (collapsed) {
     const inputPins = data.externalPins.filter((p) => p.side === 'input');
     const outputPins = data.externalPins.filter((p) => p.side === 'output');
     const rowCount = Math.max(inputPins.length, outputPins.length);

--- a/packages/canvas/src/components/nodes/ModuleNode.tsx
+++ b/packages/canvas/src/components/nodes/ModuleNode.tsx
@@ -2,7 +2,7 @@ import { Handle, type Node, type NodeProps, Position } from '@xyflow/react';
 import type React from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { CANVAS_EVENTS } from '../../events';
-import { useEngine } from '../../state/engine-context';
+import { useCanvas, useEngine } from '../../state/engine-context';
 import type { NodePin, RenderNode } from '../../types/render';
 import './ModuleNode.css';
 import { pinColor } from './pinColor';
@@ -109,6 +109,7 @@ const PinRow: React.FC<PinRowProps> = ({ pin, side, top, isError }) => {
 
 const ModuleNode: React.FC<NodeProps<ModuleNodeNode>> = ({ id, data }) => {
   const engine = useEngine();
+  const { readOnly } = useCanvas();
   const [editing, setEditing] = useState(false);
   const [editValue, setEditValue] = useState(id);
   const [hovered, setHovered] = useState(false);
@@ -145,11 +146,12 @@ const ModuleNode: React.FC<NodeProps<ModuleNodeNode>> = ({ id, data }) => {
 
   const onDoubleClick = useCallback(
     (e: React.MouseEvent) => {
+      if (readOnly) return;
       e.stopPropagation();
       setEditValue(id);
       setEditing(true);
     },
-    [id],
+    [id, readOnly],
   );
 
   const commitRename = useCallback(async () => {
@@ -287,7 +289,7 @@ const ModuleNode: React.FC<NodeProps<ModuleNodeNode>> = ({ id, data }) => {
           </span>
         )}
 
-        {hovered && (
+        {hovered && !readOnly && (
           <button
             type="button"
             onClick={onDeleteInstance}

--- a/packages/canvas/src/components/panels/EdgeInspectorPanel.tsx
+++ b/packages/canvas/src/components/panels/EdgeInspectorPanel.tsx
@@ -1,4 +1,5 @@
 import { Panel } from '@lace/ui';
+import { useCanvas } from '../../state/engine-context';
 import './EdgeInspectorPanel.css';
 
 type Props = {
@@ -18,6 +19,7 @@ export default function EdgeInspectorPanel({
   onDelete,
   onClose,
 }: Props) {
+  const { readOnly } = useCanvas();
   const title = (
     <div>
       <div className="lace-edge-panel__title-eyebrow">Connection</div>
@@ -27,7 +29,7 @@ export default function EdgeInspectorPanel({
     </div>
   );
 
-  const footer = (
+  const footer = readOnly ? undefined : (
     <button type="button" className="lace-edge-panel__delete-btn" onClick={onDelete}>
       Delete connection
     </button>
@@ -41,10 +43,12 @@ export default function EdgeInspectorPanel({
         <div className="lace-edge-panel__wiring-arrow">↓</div>
         {target}.inputs.{targetInput}
       </div>
-      <div className="lace-edge-panel__hint">
-        Delete or press Backspace with the edge selected to remove this connection. Create new edges
-        by dragging between the pins on each node's edge.
-      </div>
+      {!readOnly && (
+        <div className="lace-edge-panel__hint">
+          Delete or press Backspace with the edge selected to remove this connection. Create new
+          edges by dragging between the pins on each node's edge.
+        </div>
+      )}
     </Panel>
   );
 }

--- a/packages/canvas/src/components/panels/EnvironmentsPanel.tsx
+++ b/packages/canvas/src/components/panels/EnvironmentsPanel.tsx
@@ -44,10 +44,11 @@ function fromEnvRows(rows: EnvRow[]): Record<string, Record<string, unknown>> {
 
 type ContentProps = {
   environments: Record<string, Record<string, unknown>> | undefined;
+  readOnly?: boolean;
   onSave: (environments: Record<string, Record<string, unknown>>) => void | Promise<void>;
 };
 
-export function EnvironmentsContent({ environments, onSave }: ContentProps) {
+export function EnvironmentsContent({ environments, readOnly = false, onSave }: ContentProps) {
   const [envRows, setEnvRows] = useState<EnvRow[]>(() => toEnvRows(environments));
 
   const addEnv = useCallback(() => {
@@ -122,15 +123,18 @@ export function EnvironmentsContent({ environments, onSave }: ContentProps) {
               placeholder="Environment name (e.g. dev)"
               fullWidth
               error={envNameDupes.has(ei)}
+              readOnly={readOnly}
             />
-            <button
-              type="button"
-              onClick={() => removeEnv(ei)}
-              className="lace-panel-remove-btn"
-              aria-label="Remove environment"
-            >
-              ✕
-            </button>
+            {!readOnly && (
+              <button
+                type="button"
+                onClick={() => removeEnv(ei)}
+                className="lace-panel-remove-btn"
+                aria-label="Remove environment"
+              >
+                ✕
+              </button>
+            )}
           </div>
           {envNameDupes.has(ei) && (
             <div className="lace-panel-row-error">Duplicate environment name</div>
@@ -146,47 +150,57 @@ export function EnvironmentsContent({ environments, onSave }: ContentProps) {
                 fullWidth
                 error={envVarDupes[ei]?.has(vi)}
                 title={envVarDupes[ei]?.has(vi) ? 'Duplicate variable name' : undefined}
+                readOnly={readOnly}
               />
               <Input
                 value={v.value}
                 onChange={(e) => updateEnvVar(ei, vi, 'value', e.target.value)}
                 placeholder="Value"
                 fullWidth
+                readOnly={readOnly}
               />
-              <button
-                type="button"
-                onClick={() => removeEnvVar(ei, vi)}
-                className="lace-panel-remove-btn lace-panel-remove-btn--sm"
-                aria-label="Remove variable"
-              >
-                ✕
-              </button>
+              {!readOnly && (
+                <button
+                  type="button"
+                  onClick={() => removeEnvVar(ei, vi)}
+                  className="lace-panel-remove-btn lace-panel-remove-btn--sm"
+                  aria-label="Remove variable"
+                >
+                  ✕
+                </button>
+              )}
             </div>
           ))}
-          <button
-            type="button"
-            onClick={() => addEnvVar(ei)}
-            className="lace-panel-add-btn lace-panel-add-btn--sm"
-          >
-            + Add variable
-          </button>
+          {!readOnly && (
+            <button
+              type="button"
+              onClick={() => addEnvVar(ei)}
+              className="lace-panel-add-btn lace-panel-add-btn--sm"
+            >
+              + Add variable
+            </button>
+          )}
         </div>
       ))}
-      <button type="button" onClick={addEnv} className="lace-panel-add-btn">
-        + Add environment
-      </button>
+      {!readOnly && (
+        <>
+          <button type="button" onClick={addEnv} className="lace-panel-add-btn">
+            + Add environment
+          </button>
 
-      <SaveButton
-        status={saveStatus}
-        label="Save environments"
-        onClick={handleSave}
-        disabled={hasDuplicates}
-        disabledTitle="Fix duplicate names before saving"
-      />
-      {hasDuplicates && (
-        <div className="lace-panel-row-error">
-          Fix duplicate environment or variable names before saving.
-        </div>
+          <SaveButton
+            status={saveStatus}
+            label="Save environments"
+            onClick={handleSave}
+            disabled={hasDuplicates}
+            disabledTitle="Fix duplicate names before saving"
+          />
+          {hasDuplicates && (
+            <div className="lace-panel-row-error">
+              Fix duplicate environment or variable names before saving.
+            </div>
+          )}
+        </>
       )}
     </>
   );

--- a/packages/canvas/src/components/panels/LocalsPanel.tsx
+++ b/packages/canvas/src/components/panels/LocalsPanel.tsx
@@ -51,10 +51,11 @@ const BINDING_MODE_ITEMS = [
 
 type ContentProps = {
   locals: LocalEntry[] | undefined;
+  readOnly?: boolean;
   onSave: (locals: LocalEntry[]) => void | Promise<void>;
 };
 
-export function LocalsContent({ locals, onSave }: ContentProps) {
+export function LocalsContent({ locals, readOnly = false, onSave }: ContentProps) {
   const [rows, setRows] = useState<LocalRow[]>(() => toRows(locals));
 
   const addLocal = useCallback(() => {
@@ -103,15 +104,18 @@ export function LocalsContent({ locals, onSave }: ContentProps) {
               fullWidth
               mono
               error={nameDupes.has(i)}
+              readOnly={readOnly}
             />
-            <button
-              type="button"
-              onClick={() => removeLocal(i)}
-              className="lace-panel-remove-btn"
-              aria-label="Remove local"
-            >
-              ✕
-            </button>
+            {!readOnly && (
+              <button
+                type="button"
+                onClick={() => removeLocal(i)}
+                className="lace-panel-remove-btn"
+                aria-label="Remove local"
+              >
+                ✕
+              </button>
+            )}
           </div>
           {nameDupes.has(i) && <div className="lace-panel-row-error">Duplicate local name</div>}
 
@@ -119,7 +123,7 @@ export function LocalsContent({ locals, onSave }: ContentProps) {
             <ModeToggle<BindingMode>
               value={row.mode}
               onChange={(next) => switchMode(i, next)}
-              items={BINDING_MODE_ITEMS}
+              items={BINDING_MODE_ITEMS.map((it) => ({ ...it, disabled: readOnly }))}
               aria-label="Local binding mode"
             />
           </div>
@@ -133,6 +137,7 @@ export function LocalsContent({ locals, onSave }: ContentProps) {
                 rows={3}
                 fullWidth
                 mono
+                readOnly={readOnly}
               />
             ) : (
               <Textarea
@@ -142,23 +147,28 @@ export function LocalsContent({ locals, onSave }: ContentProps) {
                 rows={3}
                 fullWidth
                 mono
+                readOnly={readOnly}
               />
             )}
           </div>
         </div>
       ))}
 
-      <button type="button" onClick={addLocal} className="lace-panel-add-btn">
-        + Add local
-      </button>
+      {!readOnly && (
+        <>
+          <button type="button" onClick={addLocal} className="lace-panel-add-btn">
+            + Add local
+          </button>
 
-      <SaveButton
-        status={saveStatus}
-        label="Save locals"
-        onClick={handleSave}
-        disabled={hasErrors}
-        disabledTitle="Fix errors before saving"
-      />
+          <SaveButton
+            status={saveStatus}
+            label="Save locals"
+            onClick={handleSave}
+            disabled={hasErrors}
+            disabledTitle="Fix errors before saving"
+          />
+        </>
+      )}
     </>
   );
 }

--- a/packages/canvas/src/components/panels/ModuleConfigPanel.tsx
+++ b/packages/canvas/src/components/panels/ModuleConfigPanel.tsx
@@ -32,7 +32,7 @@ type Props = {
 // ── Component ──
 
 export default function ModuleConfigPanel({ instance_id, engine, onClose, onModified }: Props) {
-  const { state, updateView } = useCanvas();
+  const { state, updateView, readOnly } = useCanvas();
   const [config, setConfig] = useState<NodeConfig | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -203,10 +203,11 @@ export default function ModuleConfigPanel({ instance_id, engine, onClose, onModi
     const isWired = currentMode === 'wired';
     // Wired is always disabled (set by connect/disconnect). When the
     // current mode is wired, Lit/Var/Expr are also disabled so the user
-    // can't silently overwrite a live binding.
+    // can't silently overwrite a live binding. In read-only, every
+    // item disables.
     const items = MODE_ITEMS.map((m) => ({
       ...m,
-      disabled: m.value === 'wired' || isWired,
+      disabled: readOnly || m.value === 'wired' || isWired,
     }));
     return (
       <ModeToggle<BindingMode>
@@ -254,15 +255,17 @@ export default function ModuleConfigPanel({ instance_id, engine, onClose, onModi
         <Badge variant="info" size="md">
           Wired
         </Badge>
-        <Button
-          variant="danger"
-          size="sm"
-          onClick={() => handleDisconnect(input.name)}
-          title="Disconnect this input"
-          aria-label="Disconnect"
-        >
-          ✕
-        </Button>
+        {!readOnly && (
+          <Button
+            variant="danger"
+            size="sm"
+            onClick={() => handleDisconnect(input.name)}
+            title="Disconnect this input"
+            aria-label="Disconnect"
+          >
+            ✕
+          </Button>
+        )}
       </div>
     );
   }
@@ -280,6 +283,7 @@ export default function ModuleConfigPanel({ instance_id, engine, onClose, onModi
         placeholder="e.g. region"
         fullWidth
         mono
+        readOnly={readOnly}
       />
     );
   }
@@ -294,6 +298,7 @@ export default function ModuleConfigPanel({ instance_id, engine, onClose, onModi
         placeholder='e.g. join("-", [var.prefix, var.name])'
         fullWidth
         mono
+        readOnly={readOnly}
       />
     );
   }
@@ -312,6 +317,7 @@ export default function ModuleConfigPanel({ instance_id, engine, onClose, onModi
           className="lace-mcp__select"
           value={String(value ?? false)}
           onChange={(e) => updateValue(e.target.value === 'true')}
+          disabled={readOnly}
         >
           <option value="true">True</option>
           <option value="false">False</option>
@@ -326,6 +332,7 @@ export default function ModuleConfigPanel({ instance_id, engine, onClose, onModi
           value={String(value ?? '')}
           onChange={(e) => updateValue(e.target.value === '' ? '' : Number(e.target.value))}
           fullWidth
+          readOnly={readOnly}
         />
       );
     }
@@ -351,6 +358,7 @@ export default function ModuleConfigPanel({ instance_id, engine, onClose, onModi
           rows={4}
           fullWidth
           mono
+          readOnly={readOnly}
         />
       );
     }
@@ -369,6 +377,7 @@ export default function ModuleConfigPanel({ instance_id, engine, onClose, onModi
           updateValue(v);
         }}
         fullWidth
+        readOnly={readOnly}
       />
     );
   }
@@ -401,7 +410,7 @@ export default function ModuleConfigPanel({ instance_id, engine, onClose, onModi
     </div>
   );
 
-  const footer = (
+  const footer = readOnly ? undefined : (
     <Button variant="primary" fullWidth onClick={handleSave}>
       Save configuration
     </Button>
@@ -437,6 +446,7 @@ export default function ModuleConfigPanel({ instance_id, engine, onClose, onModi
                   type="checkbox"
                   className="lace-mcp__depends-checkbox"
                   checked={localDependsOn.has(depKey)}
+                  disabled={readOnly}
                   onChange={(e) => {
                     setLocalDependsOn((prev) => {
                       const next = new Set(prev);

--- a/packages/canvas/src/components/panels/ProvidersPanel.tsx
+++ b/packages/canvas/src/components/panels/ProvidersPanel.tsx
@@ -52,10 +52,11 @@ function fromRows(rows: ProviderRow[]): ProviderEntry[] {
 
 type ContentProps = {
   providers: ProviderEntry[] | undefined;
+  readOnly?: boolean;
   onSave: (providers: ProviderEntry[]) => void | Promise<void>;
 };
 
-export function ProvidersContent({ providers, onSave }: ContentProps) {
+export function ProvidersContent({ providers, readOnly = false, onSave }: ContentProps) {
   const [rows, setRows] = useState<ProviderRow[]>(() => toRows(providers));
 
   const addProvider = useCallback(() => {
@@ -127,21 +128,25 @@ export function ProvidersContent({ providers, onSave }: ContentProps) {
               onChange={(e) => updateField(pi, 'name', e.target.value)}
               placeholder="Provider name (e.g. aws)"
               fullWidth
+              readOnly={readOnly}
             />
             <Input
               value={row.alias}
               onChange={(e) => updateField(pi, 'alias', e.target.value)}
               placeholder="Alias (optional)"
               fullWidth
+              readOnly={readOnly}
             />
-            <button
-              type="button"
-              onClick={() => removeProvider(pi)}
-              className="lace-panel-remove-btn"
-              aria-label="Remove provider"
-            >
-              ✕
-            </button>
+            {!readOnly && (
+              <button
+                type="button"
+                onClick={() => removeProvider(pi)}
+                className="lace-panel-remove-btn"
+                aria-label="Remove provider"
+              >
+                ✕
+              </button>
+            )}
           </div>
 
           <div className="lace-panel-row-sublabel">Config</div>
@@ -152,38 +157,48 @@ export function ProvidersContent({ providers, onSave }: ContentProps) {
                 onChange={(e) => updateConfigEntry(pi, ei, 'key', e.target.value)}
                 placeholder="Key"
                 fullWidth
+                readOnly={readOnly}
               />
               <Input
                 value={entry.value}
                 onChange={(e) => updateConfigEntry(pi, ei, 'value', e.target.value)}
                 placeholder="Value"
                 fullWidth
+                readOnly={readOnly}
               />
-              <button
-                type="button"
-                onClick={() => removeConfigEntry(pi, ei)}
-                className="lace-panel-remove-btn lace-panel-remove-btn--sm"
-                aria-label="Remove config key"
-              >
-                ✕
-              </button>
+              {!readOnly && (
+                <button
+                  type="button"
+                  onClick={() => removeConfigEntry(pi, ei)}
+                  className="lace-panel-remove-btn lace-panel-remove-btn--sm"
+                  aria-label="Remove config key"
+                >
+                  ✕
+                </button>
+              )}
             </div>
           ))}
-          <button
-            type="button"
-            onClick={() => addConfigEntry(pi)}
-            className="lace-panel-add-btn lace-panel-add-btn--sm"
-          >
-            + Add config key
-          </button>
+          {!readOnly && (
+            <button
+              type="button"
+              onClick={() => addConfigEntry(pi)}
+              className="lace-panel-add-btn lace-panel-add-btn--sm"
+            >
+              + Add config key
+            </button>
+          )}
         </div>
       ))}
 
-      <button type="button" onClick={addProvider} className="lace-panel-add-btn">
-        + Add provider
-      </button>
+      {!readOnly && (
+        <>
+          <button type="button" onClick={addProvider} className="lace-panel-add-btn">
+            + Add provider
+          </button>
 
-      <SaveButton status={saveStatus} label="Save providers" onClick={handleSave} />
+          <SaveButton status={saveStatus} label="Save providers" onClick={handleSave} />
+        </>
+      )}
     </>
   );
 }

--- a/packages/canvas/src/components/panels/TerraformConfigPanel.tsx
+++ b/packages/canvas/src/components/panels/TerraformConfigPanel.tsx
@@ -16,10 +16,11 @@ type ProviderRequirementRow = { name: string; source: string; version: string };
 
 type ContentProps = {
   terraform: TerraformConfig | undefined;
+  readOnly?: boolean;
   onSave: (terraform: TerraformConfig) => void | Promise<void>;
 };
 
-export function TerraformConfigContent({ terraform, onSave }: ContentProps) {
+export function TerraformConfigContent({ terraform, readOnly = false, onSave }: ContentProps) {
   const [requiredVersion, setRequiredVersion] = useState(terraform?.required_version ?? '');
   const [providers, setProviders] = useState<ProviderRequirementRow[]>(() => {
     if (!terraform?.required_providers) return [];
@@ -70,6 +71,7 @@ export function TerraformConfigContent({ terraform, onSave }: ContentProps) {
           onChange={(e) => setRequiredVersion(e.target.value)}
           placeholder=">= 1.5"
           fullWidth
+          readOnly={readOnly}
         />
       </div>
 
@@ -82,14 +84,17 @@ export function TerraformConfigContent({ terraform, onSave }: ContentProps) {
               onChange={(e) => updateProvider(i, 'name', e.target.value)}
               placeholder="Name (e.g. aws)"
               fullWidth
+              readOnly={readOnly}
             />
-            <button
-              type="button"
-              onClick={() => removeProvider(i)}
-              className="lace-panel-remove-btn"
-            >
-              Remove
-            </button>
+            {!readOnly && (
+              <button
+                type="button"
+                onClick={() => removeProvider(i)}
+                className="lace-panel-remove-btn"
+              >
+                Remove
+              </button>
+            )}
           </div>
           <div className="lace-panel-row-actions">
             <Input
@@ -97,6 +102,7 @@ export function TerraformConfigContent({ terraform, onSave }: ContentProps) {
               onChange={(e) => updateProvider(i, 'source', e.target.value)}
               placeholder="Source (e.g. hashicorp/aws)"
               fullWidth
+              readOnly={readOnly}
             />
           </div>
           <div className="lace-panel-row-actions">
@@ -105,13 +111,16 @@ export function TerraformConfigContent({ terraform, onSave }: ContentProps) {
               onChange={(e) => updateProvider(i, 'version', e.target.value)}
               placeholder="Version (e.g. ~> 5.0)"
               fullWidth
+              readOnly={readOnly}
             />
           </div>
         </div>
       ))}
-      <button type="button" onClick={addProvider} className="lace-panel-add-btn">
-        + Add provider
-      </button>
+      {!readOnly && (
+        <button type="button" onClick={addProvider} className="lace-panel-add-btn">
+          + Add provider
+        </button>
+      )}
 
       <h4 className="lace-panel-section-title">Backend</h4>
       <div className="lace-panel-hint">
@@ -119,7 +128,9 @@ export function TerraformConfigContent({ terraform, onSave }: ContentProps) {
         during generation.
       </div>
 
-      <SaveButton status={saveStatus} label="Save configuration" onClick={handleSave} />
+      {!readOnly && (
+        <SaveButton status={saveStatus} label="Save configuration" onClick={handleSave} />
+      )}
     </>
   );
 }

--- a/packages/canvas/src/components/panels/UnifiedSettingsPanel.tsx
+++ b/packages/canvas/src/components/panels/UnifiedSettingsPanel.tsx
@@ -2,6 +2,7 @@
 import { Panel } from '@lace/ui';
 import { useEffect, useState } from 'react';
 import type { CanvasEngine } from '../../engine';
+import { useCanvas } from '../../state/engine-context';
 import type { SettingsConfig } from '../../types/render';
 import AccordionSection from '../AccordionSection';
 import { EnvironmentsContent } from './EnvironmentsPanel';
@@ -17,6 +18,7 @@ type Props = {
 };
 
 export default function UnifiedSettingsPanel({ engine, onClose, onSaved }: Props) {
+  const { readOnly } = useCanvas();
   const [settings, setSettings] = useState<SettingsConfig | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -47,6 +49,7 @@ export default function UnifiedSettingsPanel({ engine, onClose, onSaved }: Props
       <AccordionSection title="Terraform Config" defaultOpen>
         <TerraformConfigContent
           terraform={settings.terraform}
+          readOnly={readOnly}
           onSave={async (terraform) => {
             await engine.setTerraform(
               terraform.required_version,
@@ -66,6 +69,7 @@ export default function UnifiedSettingsPanel({ engine, onClose, onSaved }: Props
       <AccordionSection title="Providers">
         <ProvidersContent
           providers={settings.providers}
+          readOnly={readOnly}
           onSave={async (providers) => {
             await engine.setProviders(
               providers.map((p) => ({
@@ -82,6 +86,7 @@ export default function UnifiedSettingsPanel({ engine, onClose, onSaved }: Props
       <AccordionSection title="Locals">
         <LocalsContent
           locals={settings.locals}
+          readOnly={readOnly}
           onSave={async (locals) => {
             await engine.setLocals(
               locals.map((l) => {
@@ -106,6 +111,7 @@ export default function UnifiedSettingsPanel({ engine, onClose, onSaved }: Props
       <AccordionSection title="Environments">
         <EnvironmentsContent
           environments={settings.environments}
+          readOnly={readOnly}
           onSave={async (environments) => {
             await engine.setEnvironments(environments);
             onSaved?.();

--- a/packages/canvas/src/hooks/useClipboard.ts
+++ b/packages/canvas/src/hooks/useClipboard.ts
@@ -12,6 +12,7 @@ export function useClipboard(
   selectNodes: (ids: string[]) => void,
   getContextMenuNodeId: () => string | null,
   dismissContextMenu: () => void,
+  readOnly: boolean,
 ) {
   const clipboardRef = useRef<string[]>([]);
   const isCutRef = useRef(false);
@@ -77,8 +78,11 @@ export function useClipboard(
     }
   }, [engine, updateView, view, showToast, selectNodes, dismissContextMenu]);
 
-  // Expose globally for HTML-level keyboard shortcuts
+  // Expose globally for HTML-level keyboard shortcuts. In read-only we
+  // skip the install so Cmd+C/X/V route through their host-side
+  // handlers, find `window.__canvas*` undefined, and no-op.
   useEffect(() => {
+    if (readOnly) return;
     window.__canvasCopy = onCopy;
     window.__canvasCut = onCut;
     window.__canvasPaste = onPaste;
@@ -87,7 +91,7 @@ export function useClipboard(
       window.__canvasCut = undefined;
       window.__canvasPaste = undefined;
     };
-  }, [onCopy, onCut, onPaste]);
+  }, [onCopy, onCut, onPaste, readOnly]);
 
   return { onCopy, onCut, onPaste };
 }

--- a/packages/canvas/src/hooks/useWindowEvent.ts
+++ b/packages/canvas/src/hooks/useWindowEvent.ts
@@ -2,14 +2,23 @@ import { useEffect } from 'react';
 
 /**
  * Attach a window event listener with automatic cleanup.
+ *
+ * Pass `{ enabled: false }` to opt out of installing the listener —
+ * e.g. to leave a mutation-triggering event unhandled in read-only
+ * mode. An uninstalled listener is silent by construction; the
+ * alternative (install + guard inside the handler) leaves the
+ * attach/detach side-effect running for no reason.
  */
 export function useWindowEvent<K extends string>(
   eventName: K,
   handler: (e: Event) => void,
   deps: React.DependencyList,
+  options?: { enabled?: boolean },
 ) {
+  const enabled = options?.enabled ?? true;
   useEffect(() => {
+    if (!enabled) return;
     window.addEventListener(eventName, handler);
     return () => window.removeEventListener(eventName, handler);
-  }, [eventName, ...deps]);
+  }, [eventName, enabled, ...deps]);
 }

--- a/packages/canvas/src/state/engine-context.ts
+++ b/packages/canvas/src/state/engine-context.ts
@@ -15,6 +15,17 @@ export type CanvasContextValue = {
   state: CanvasState;
   engine: CanvasEngine | null;
   updateView: (view: CanvasView) => void;
+  // Read-only mode. In read-only, view-only interactions (drag,
+  // expand/collapse, inspection) remain; IR mutations (delete,
+  // rename, wire, save) are gated off.
+  readOnly: boolean;
+  // In read-only we let users expand/collapse groups as a view op,
+  // but must not persist it via engine.updateGroup. We stash the
+  // override at the provider level so useGroupLogic (which drives
+  // xyflow's child-node hiding) can read the effective collapsed
+  // flag from a single source of truth.
+  localGroupCollapseOverrides: Record<string, boolean>;
+  toggleLocalGroupCollapse: (groupId: string, currentCollapsed: boolean) => void;
 };
 
 export const CanvasContext = createContext<CanvasContextValue>({
@@ -28,6 +39,9 @@ export const CanvasContext = createContext<CanvasContextValue>({
   },
   engine: null,
   updateView: () => {},
+  readOnly: false,
+  localGroupCollapseOverrides: {},
+  toggleLocalGroupCollapse: () => {},
 });
 
 export function useCanvas(): CanvasContextValue {


### PR DESCRIPTION
## Summary

Closes out the canvas rebuild arc by adding a `readOnly` mode on `@lace/canvas`, making the canvas mountable in inspection-only contexts (portal is the named next consumer). After this, the canvas package is ready for extraction/external consumption.

The semantic contract is **view manipulation vs. IR mutation**:
- **Allowed:** pan, zoom, selection, hover/tooltip, MiniMap toggle, drag-to-reposition (local only), expand/collapse groups (local override), open panels for inspection.
- **Blocked:** Save, Generate, delete, rename, connect/reconnect, create group, ungroup, edit any input in any panel, Undo/Redo, Clear all, copy/cut/paste, context menu.

### Three-layer gating principle

Each gate sits at the layer closest to its concern — no belt-and-suspenders.

1. **xyflow native props** — `nodesConnectable={!readOnly}`, `edgesReconnectable={!readOnly}`, `deleteKeyCode={readOnly ? null : [...]}`. xyflow already gates these; we use its API instead of re-implementing at the handler layer.
2. **Conditional handler installation** — `SAVE` / `GENERATE` `useWindowEvent`, `window.__canvasUndo` / `__canvasCopy` / `__canvasCut` / `__canvasPaste` are skipped when `readOnly`. Host-side Cmd+S/Z/C/X/V dispatches fall through to a no-op because nothing is installed.
3. **Render gates** — ActionBar collapses to `MiniMap toggle + Settings gear`; ModuleNode/GroupNode hover-delete + ungroup render `null`; panel Save/Disconnect/Add/Remove CTAs render `null`; `Input`/`Textarea` forward `readOnly`; `ModeToggle` items all `disabled`.

### One structural change — group collapse

Collapse is a view op that normally persists via `engine.updateGroup({collapsed})`. In read-only we must not round-trip through the engine, but the visual should still work end-to-end (chevron, child hiding, external pin computation).

`CanvasContext` now carries `localGroupCollapseOverrides`. `App` owns the state; `Canvas` merges overrides into `view.groups` before handing it to `useGroupLogic`. One source of truth; no ad-hoc overlays.

### New/changed stories (for Chromatic review)

- **`Flows / Scene / ReadOnly`** — canvas mounted with `readOnly` via iam-stack fixture. Canonical coverage for the read-only composition.
- **`Components / ActionBar / ReadOnly`** — locks the 2-icon shape.
- **`Panels / ModuleConfigPanel / ReadOnly`** — inputs carry `readonly`, ModeToggle all disabled, no Save, no Disconnect.

No changes to existing editor-mode stories — all default story shapes are unchanged (verified: `Flows/Scene/SaveSuccess` still renders 7 ActionBar buttons; `Panels/ModuleConfigPanel/Populated…` still has editable inputs + Save).

## Test plan

- [x] `npx tsc --noEmit` — green.
- [x] `pnpm test:unit` — 123 tests pass.
- [x] `pnpm run lint` — green.
- [x] `pnpm run build` — all three bundles compile.
- [x] `pnpm run storybook:build` — green.
- [x] Playwright MCP DOM checks:
  - `Flows/Scene/ReadOnly` — `.lace-action-bar button` count = 2; labels = `['Show minimap', 'Settings']`; `Save`/`Clear all`/`Undo`/`Redo`/`Generate` absent; `.lace-module-node__delete-btn` never appears (even on hover).
  - `Panels/ModuleConfigPanel/ReadOnly` — every `<input>` has `readOnly=true`, no "Save configuration" button, no `aria-label="Disconnect"`, all `button[aria-pressed]` (ModeToggle items) are `disabled`.
  - Editor regression: `Flows/Scene/SaveSuccess` still renders all 7 ActionBar buttons; editable `ModuleConfigPanel` variants still have 2 editable inputs + Save CTA.
- [ ] Chromatic visual approval on the new stories.
- [ ] Smoke test in the VS Code webview to confirm editor mode is untouched (extension entry never sets `readOnly`, defaults to `false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)