### PR TITLE
test(chat-sidebar): adapter coverage for vscode-part-codec, transport, workspace-tools

### DIFF
--- a/packages/chat-sidebar/src/__tests__/test-utils/vscode-mock.ts
+++ b/packages/chat-sidebar/src/__tests__/test-utils/vscode-mock.ts
@@ -1,0 +1,107 @@
+// Per-test vscode mock factory.
+//
+// PR A deleted the global vitest.setup.ts vscode mock as part of the
+// greenfield host split — vscode-free packages must run their tests
+// with no ambient vscode shim. Chat-sidebar tests that exercise the
+// VS Code adapter explicitly install this mock at the top of the
+// file via:
+//
+//   import { vi } from 'vitest';
+//   import { createVscodeMock } from './test-utils/vscode-mock';
+//   vi.mock('vscode', () => createVscodeMock());
+//
+// Per-file mocks make scope explicit at the call site — no implicit
+// ambient state. The factory shape matches the minimal vscode surface
+// the chat-sidebar adapter touches; expand as new adapter code under
+// test reaches for additional vscode APIs.
+
+export function createVscodeMock() {
+  // ── LM part classes ──
+  // Stand-ins for VS Code's `LanguageModel*Part` runtime classes.
+  // Real classes carry no extra behaviour beyond the constructor —
+  // these mirror that exactly so `instanceof` checks in
+  // vscode-part-codec work.
+  class LanguageModelTextPart {
+    constructor(public value: string) {}
+  }
+  class LanguageModelToolCallPart {
+    constructor(
+      public callId: string,
+      public name: string,
+      public input: unknown,
+    ) {}
+  }
+  class LanguageModelToolResultPart {
+    constructor(
+      public callId: string,
+      public content: LanguageModelTextPart[],
+    ) {}
+  }
+
+  // ── Chat message ──
+  // Real factory functions accept either a string or an array of
+  // parts; the factory returns an instance carrying role + content.
+  class LanguageModelChatMessage {
+    constructor(
+      public role: number,
+      public content: unknown,
+    ) {}
+    static User(content: unknown) {
+      return new LanguageModelChatMessage(1, content);
+    }
+    static Assistant(content: unknown) {
+      return new LanguageModelChatMessage(2, content);
+    }
+  }
+
+  // ── EventEmitter ──
+  // Minimal Disposable-returning subscribe API + a `fire` for tests.
+  class EventEmitter<T> {
+    private readonly listeners: Array<(value: T) => void> = [];
+    event = (listener: (value: T) => void) => {
+      this.listeners.push(listener);
+      return {
+        dispose: () => {
+          const i = this.listeners.indexOf(listener);
+          if (i >= 0) this.listeners.splice(i, 1);
+        },
+      };
+    };
+    fire(value: T) {
+      for (const listener of this.listeners) listener(value);
+    }
+    dispose() {
+      this.listeners.length = 0;
+    }
+  }
+
+  return {
+    LanguageModelTextPart,
+    LanguageModelToolCallPart,
+    LanguageModelToolResultPart,
+    LanguageModelChatMessage,
+    LanguageModelChatMessageRole: { User: 1, Assistant: 2 },
+    EventEmitter,
+    workspace: {
+      workspaceFolders: undefined as
+        | undefined
+        | Array<{ uri: { fsPath: string }; name: string; index: number }>,
+      getConfiguration: () => ({
+        get: <T>(_key: string, defaultValue: T) => defaultValue,
+      }),
+    },
+    window: {
+      createOutputChannel: () => ({ appendLine: () => {}, dispose: () => {} }),
+      showErrorMessage: () => Promise.resolve(undefined),
+      showInformationMessage: () => Promise.resolve(undefined),
+    },
+    commands: {
+      registerCommand: () => ({ dispose: () => {} }),
+      executeCommand: async () => undefined,
+    },
+    Uri: {
+      file: (p: string) => ({ fsPath: p }),
+      joinPath: (..._args: unknown[]) => ({ fsPath: '' }),
+    },
+  };
+}

--- a/packages/chat-sidebar/src/__tests__/vscode-part-codec.test.ts
+++ b/packages/chat-sidebar/src/__tests__/vscode-part-codec.test.ts
@@ -1,0 +1,224 @@
+import type { ChatMessage, ChatStreamEvent } from '@lace-cloud/chat-core';
+import { describe, expect, test, vi } from 'vitest';
+import * as vscode from 'vscode';
+import {
+  abortSignalToToken,
+  toVscodeMessage,
+  vscodePartToCore,
+  vscodeStreamToEvents,
+} from '../vscode-part-codec';
+
+// vi.mock with an async factory runs lazily at first vscode import —
+// the dynamic `await import` resolves the shared factory module
+// correctly. Synchronous factories are hoisted above static imports
+// and can't reference outer-scope identifiers, which is why we don't
+// use `import { createVscodeMock }` at the top.
+vi.mock('vscode', async () => {
+  const { createVscodeMock } = await import('./test-utils/vscode-mock');
+  return createVscodeMock();
+});
+
+// ── Core → VS Code ──
+
+describe('toVscodeMessage', () => {
+  test('user message wraps text + tool-call + tool-result parts', () => {
+    const msg: ChatMessage = {
+      role: 'user',
+      content: [
+        { kind: 'text', value: 'hello' },
+        {
+          kind: 'tool-call',
+          callId: 'call-1',
+          name: 'lace_describe_graph',
+          input: { detail: 'full' },
+        },
+        {
+          kind: 'tool-result',
+          callId: 'call-1',
+          content: [{ kind: 'text', value: 'graph state...' }],
+        },
+      ],
+    };
+    const result = toVscodeMessage(msg);
+    expect(result.role).toBe(vscode.LanguageModelChatMessageRole.User);
+    const parts = result.content as unknown as Array<{
+      value?: string;
+      callId?: string;
+      name?: string;
+      input?: unknown;
+      content?: unknown[];
+    }>;
+    expect(parts).toHaveLength(3);
+    expect(parts[0]).toBeInstanceOf(vscode.LanguageModelTextPart);
+    expect(parts[0].value).toBe('hello');
+    expect(parts[1]).toBeInstanceOf(vscode.LanguageModelToolCallPart);
+    expect(parts[1].callId).toBe('call-1');
+    expect(parts[1].name).toBe('lace_describe_graph');
+    expect(parts[1].input).toEqual({ detail: 'full' });
+    expect(parts[2]).toBeInstanceOf(vscode.LanguageModelToolResultPart);
+    expect(parts[2].callId).toBe('call-1');
+    const inner = parts[2].content as Array<{ value: string }>;
+    expect(inner).toHaveLength(1);
+    expect(inner[0].value).toBe('graph state...');
+  });
+
+  test('assistant message uses Assistant role', () => {
+    const msg: ChatMessage = {
+      role: 'assistant',
+      content: [{ kind: 'text', value: 'sure thing' }],
+    };
+    const result = toVscodeMessage(msg);
+    expect(result.role).toBe(vscode.LanguageModelChatMessageRole.Assistant);
+  });
+
+  test('tool-call with undefined input becomes empty object', () => {
+    const msg: ChatMessage = {
+      role: 'user',
+      content: [{ kind: 'tool-call', callId: 'c', name: 'noop', input: undefined }],
+    };
+    const result = toVscodeMessage(msg);
+    const parts = result.content as unknown as Array<{ input: unknown }>;
+    expect(parts[0].input).toEqual({});
+  });
+});
+
+// ── VS Code stream → Core stream events ──
+
+describe('vscodeStreamToEvents', () => {
+  test('yields text events for LanguageModelTextPart', async () => {
+    const stream = (async function* () {
+      yield new vscode.LanguageModelTextPart('one');
+      yield new vscode.LanguageModelTextPart('two');
+    })();
+
+    const events: ChatStreamEvent[] = [];
+    for await (const ev of vscodeStreamToEvents(stream)) events.push(ev);
+
+    expect(events).toEqual([
+      { type: 'text', value: 'one' },
+      { type: 'text', value: 'two' },
+    ]);
+  });
+
+  test('yields tool-call events for LanguageModelToolCallPart', async () => {
+    const stream = (async function* () {
+      yield new vscode.LanguageModelToolCallPart('c1', 'lace_add_module', { name: 'aws_vpc' });
+    })();
+
+    const events: ChatStreamEvent[] = [];
+    for await (const ev of vscodeStreamToEvents(stream)) events.push(ev);
+
+    expect(events).toEqual([
+      { type: 'tool-call', callId: 'c1', name: 'lace_add_module', input: { name: 'aws_vpc' } },
+    ]);
+  });
+
+  test('silently drops unknown part kinds (forward-compat)', async () => {
+    class UnknownPart {
+      constructor(public payload: string) {}
+    }
+    const stream = (async function* () {
+      yield new vscode.LanguageModelTextPart('keep');
+      yield new UnknownPart('drop');
+      yield new vscode.LanguageModelTextPart('keep-too');
+    })();
+
+    const events: ChatStreamEvent[] = [];
+    for await (const ev of vscodeStreamToEvents(stream)) events.push(ev);
+
+    expect(events.map((e) => (e.type === 'text' ? e.value : null))).toEqual(['keep', 'keep-too']);
+  });
+});
+
+// ── AbortSignal → vscode.CancellationToken ──
+
+describe('abortSignalToToken', () => {
+  test('not-yet-aborted signal exposes isCancellationRequested=false', () => {
+    const controller = new AbortController();
+    const token = abortSignalToToken(controller.signal);
+    expect(token.isCancellationRequested).toBe(false);
+  });
+
+  test('aborting after token creation flips isCancellationRequested + fires onCancellationRequested', () => {
+    const controller = new AbortController();
+    const token = abortSignalToToken(controller.signal);
+    let fired = false;
+    token.onCancellationRequested(() => {
+      fired = true;
+    });
+
+    controller.abort();
+    expect(token.isCancellationRequested).toBe(true);
+    // The emitter fires synchronously on the abort event.
+    expect(fired).toBe(true);
+  });
+
+  test('already-aborted signal fires onCancellationRequested asynchronously after subscribers attach', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const token = abortSignalToToken(controller.signal);
+    expect(token.isCancellationRequested).toBe(true);
+
+    let fired = false;
+    token.onCancellationRequested(() => {
+      fired = true;
+    });
+
+    // The factory uses setTimeout(..., 0) so subscribers attached
+    // before the next microtask still observe the fire.
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(fired).toBe(true);
+  });
+});
+
+// ── VS Code → Core (text-part extraction for history restore) ──
+
+describe('vscodePartToCore', () => {
+  test('text part round-trips', () => {
+    const part = new vscode.LanguageModelTextPart('hello');
+    expect(vscodePartToCore(part)).toEqual({ kind: 'text', value: 'hello' });
+  });
+
+  test('tool-call part round-trips with full payload', () => {
+    const part = new vscode.LanguageModelToolCallPart('c1', 'lace_validate_graph', {
+      strict: true,
+    });
+    expect(vscodePartToCore(part)).toEqual({
+      kind: 'tool-call',
+      callId: 'c1',
+      name: 'lace_validate_graph',
+      input: { strict: true },
+    });
+  });
+
+  test('tool-result part keeps text-only inner content (drops non-text)', () => {
+    class NonTextPart {
+      constructor(public mime: string) {}
+    }
+    const inner = [
+      new vscode.LanguageModelTextPart('text-1'),
+      new NonTextPart('image/png') as unknown as InstanceType<typeof vscode.LanguageModelTextPart>,
+      new vscode.LanguageModelTextPart('text-2'),
+    ];
+    const part = new vscode.LanguageModelToolResultPart('c1', inner);
+    expect(vscodePartToCore(part)).toEqual({
+      kind: 'tool-result',
+      callId: 'c1',
+      content: [
+        { kind: 'text', value: 'text-1' },
+        { kind: 'text', value: 'text-2' },
+      ],
+    });
+  });
+
+  test('returns null for unrecognised part class', () => {
+    class UnknownPart {
+      constructor(public x: number) {}
+    }
+    expect(
+      vscodePartToCore(
+        new UnknownPart(42) as unknown as InstanceType<typeof vscode.LanguageModelTextPart>,
+      ),
+    ).toBeNull();
+  });
+});

--- a/packages/chat-sidebar/src/__tests__/vscode-webview-transport.test.ts
+++ b/packages/chat-sidebar/src/__tests__/vscode-webview-transport.test.ts
@@ -1,0 +1,75 @@
+import type { HostToWebview, WebviewToHost } from '@lace-cloud/chat-core';
+import { describe, expect, test, vi } from 'vitest';
+import { createVsCodeWebviewTransport } from '../vscode-webview-transport';
+
+vi.mock('vscode', async () => {
+  const { createVscodeMock } = await import('./test-utils/vscode-mock');
+  return createVscodeMock();
+});
+
+// Minimal vscode.Webview stand-in. The transport only touches
+// postMessage + onDidReceiveMessage; nothing else needs to exist.
+function fakeWebview() {
+  const posted: HostToWebview[] = [];
+  let listener: ((msg: WebviewToHost) => void) | null = null;
+  return {
+    posted,
+    fire(msg: WebviewToHost) {
+      listener?.(msg);
+    },
+    webview: {
+      postMessage(msg: HostToWebview) {
+        posted.push(msg);
+        return Promise.resolve(true);
+      },
+      onDidReceiveMessage(cb: (msg: WebviewToHost) => void) {
+        listener = cb;
+        return {
+          dispose() {
+            listener = null;
+          },
+        };
+      },
+    },
+  };
+}
+
+describe('createVsCodeWebviewTransport', () => {
+  test('postMessage forwards to vscode.Webview.postMessage', () => {
+    const fake = fakeWebview();
+    const transport = createVsCodeWebviewTransport(
+      fake.webview as unknown as Parameters<typeof createVsCodeWebviewTransport>[0],
+    );
+    transport.postMessage({ type: 'token', text: 'hello' });
+    expect(fake.posted).toEqual([{ type: 'token', text: 'hello' }]);
+  });
+
+  test('onMessage subscribes — listener fires when webview emits', () => {
+    const fake = fakeWebview();
+    const transport = createVsCodeWebviewTransport(
+      fake.webview as unknown as Parameters<typeof createVsCodeWebviewTransport>[0],
+    );
+    const received: WebviewToHost[] = [];
+    transport.onMessage((msg) => received.push(msg));
+
+    fake.fire({ type: 'webview-ready' });
+    fake.fire({ type: 'user-turn', text: 'hi' });
+
+    expect(received).toEqual([{ type: 'webview-ready' }, { type: 'user-turn', text: 'hi' }]);
+  });
+
+  test('disposing the subscription unsubscribes', () => {
+    const fake = fakeWebview();
+    const transport = createVsCodeWebviewTransport(
+      fake.webview as unknown as Parameters<typeof createVsCodeWebviewTransport>[0],
+    );
+    const received: WebviewToHost[] = [];
+    const sub = transport.onMessage((msg) => received.push(msg));
+
+    fake.fire({ type: 'webview-ready' });
+    sub.dispose();
+    fake.fire({ type: 'cancel-turn' });
+
+    expect(received).toEqual([{ type: 'webview-ready' }]);
+  });
+});

--- a/packages/chat-sidebar/src/__tests__/workspace-tools.test.ts
+++ b/packages/chat-sidebar/src/__tests__/workspace-tools.test.ts
@@ -1,0 +1,246 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+  buildProjectProfile,
+  detectCloudHints,
+  detectDatabases,
+  detectExistingModules,
+  detectFrameworks,
+  detectLanguages,
+  detectRuntimes,
+} from '../host/tools/workspace-tools';
+
+vi.mock('vscode', async () => {
+  const { createVscodeMock } = await import('./test-utils/vscode-mock');
+  return createVscodeMock();
+});
+
+// ── Pure helpers ──
+
+describe('detectLanguages', () => {
+  test('package.json → typescript/javascript', () => {
+    expect(detectLanguages(new Set(['package.json']))).toEqual(['typescript/javascript']);
+  });
+  test('go.mod → go', () => {
+    expect(detectLanguages(new Set(['go.mod']))).toEqual(['go']);
+  });
+  test('python triggers from either requirements.txt or pyproject.toml', () => {
+    expect(detectLanguages(new Set(['requirements.txt']))).toContain('python');
+    expect(detectLanguages(new Set(['pyproject.toml']))).toContain('python');
+  });
+  test('java triggers from either pom.xml or build.gradle', () => {
+    expect(detectLanguages(new Set(['pom.xml']))).toContain('java');
+    expect(detectLanguages(new Set(['build.gradle']))).toContain('java');
+  });
+  test('multi-language project lists each detected', () => {
+    const langs = detectLanguages(new Set(['package.json', 'go.mod', 'Cargo.toml', 'Gemfile']));
+    expect(langs).toEqual(expect.arrayContaining(['typescript/javascript', 'go', 'rust', 'ruby']));
+  });
+  test('empty input → empty list', () => {
+    expect(detectLanguages(new Set())).toEqual([]);
+  });
+});
+
+describe('detectFrameworks', () => {
+  test('parses package.json deps + devDependencies', () => {
+    const pkg = JSON.stringify({
+      dependencies: { express: '*', react: '*' },
+      devDependencies: { fastify: '*' },
+    });
+    const frameworks = detectFrameworks(new Map([['package.json', pkg]]));
+    expect(frameworks).toEqual(expect.arrayContaining(['express', 'fastify', 'react']));
+  });
+
+  test('next short-circuits react detection (next ships React)', () => {
+    const pkg = JSON.stringify({ dependencies: { next: '*', react: '*' } });
+    const frameworks = detectFrameworks(new Map([['package.json', pkg]]));
+    expect(frameworks).toContain('next.js');
+    expect(frameworks).not.toContain('react');
+  });
+
+  test('malformed package.json is silently skipped (no throw)', () => {
+    const frameworks = detectFrameworks(new Map([['package.json', '{ not valid json']]));
+    expect(frameworks).toEqual([]);
+  });
+
+  test('python frameworks from requirements.txt regex', () => {
+    const reqs = 'django==4.2\nfastapi>=0.100';
+    const frameworks = detectFrameworks(new Map([['requirements.txt', reqs]]));
+    expect(frameworks).toEqual(expect.arrayContaining(['django', 'fastapi']));
+  });
+
+  test('go frameworks from go.mod regex', () => {
+    const gomod =
+      'require github.com/gin-gonic/gin v1.9.0\nrequire github.com/gofiber/fiber v2.0.0';
+    const frameworks = detectFrameworks(new Map([['go.mod', gomod]]));
+    expect(frameworks).toEqual(expect.arrayContaining(['gin', 'fiber']));
+  });
+
+  test('returns [] when no recognised inputs present', () => {
+    expect(detectFrameworks(new Map())).toEqual([]);
+  });
+});
+
+describe('detectRuntimes', () => {
+  test('Dockerfile FROM line picked up', () => {
+    const docker = 'FROM node:20-alpine\nWORKDIR /app';
+    expect(detectRuntimes(new Map([['Dockerfile', docker]]))).toEqual(['node:20-alpine']);
+  });
+
+  test('docker-compose.yml is the FROM fallback when Dockerfile missing', () => {
+    const compose = 'FROM python:3.11\n# ...';
+    expect(detectRuntimes(new Map([['docker-compose.yml', compose]]))).toEqual(['python:3.11']);
+  });
+
+  test('package.json engines.node prepends node:', () => {
+    const pkg = JSON.stringify({ engines: { node: '>=20' } });
+    expect(detectRuntimes(new Map([['package.json', pkg]]))).toEqual(['node:>=20']);
+  });
+
+  test('combines Dockerfile + engines.node', () => {
+    const docker = 'FROM golang:1.22\n';
+    const pkg = JSON.stringify({ engines: { node: '20.x' } });
+    expect(
+      detectRuntimes(
+        new Map([
+          ['Dockerfile', docker],
+          ['package.json', pkg],
+        ]),
+      ),
+    ).toEqual(['golang:1.22', 'node:20.x']);
+  });
+
+  test('Dockerfile without FROM yields nothing', () => {
+    expect(detectRuntimes(new Map([['Dockerfile', '# no FROM here\n']]))).toEqual([]);
+  });
+});
+
+describe('detectDatabases', () => {
+  test('postgres detected from package.json psycopg/pg references', () => {
+    const fc = new Map([['package.json', JSON.stringify({ dependencies: { pg: '*' } })]]);
+    expect(detectDatabases(fc)).toContain('postgres');
+  });
+  test('multiple databases detected, deduplicated', () => {
+    const fc = new Map([
+      ['Dockerfile', 'FROM redis\nFROM mongodb'],
+      ['package.json', '{"dependencies":{"redis":"*","mongoose":"*"}}'],
+    ]);
+    const dbs = detectDatabases(fc);
+    expect(dbs).toEqual(expect.arrayContaining(['redis', 'mongodb']));
+    expect(new Set(dbs).size).toBe(dbs.length); // deduplicated
+  });
+  test('no matches → empty list', () => {
+    expect(detectDatabases(new Map([['README.md', 'some prose']]))).toEqual([]);
+  });
+});
+
+describe('detectCloudHints', () => {
+  test('aws detected via @aws-sdk import', () => {
+    const fc = new Map([['package.json', '{"dependencies":{"@aws-sdk/client-s3":"*"}}']]);
+    expect(detectCloudHints(fc)).toContain('aws');
+  });
+  test('azure + google both detected when present', () => {
+    const fc = new Map([
+      ['package.json', '{"dependencies":{"@azure/identity":"*","@google-cloud/storage":"*"}}'],
+    ]);
+    expect(detectCloudHints(fc)).toEqual(expect.arrayContaining(['azure', 'google']));
+  });
+  test('aws_-prefixed Terraform vars also count as aws hint', () => {
+    const fc = new Map([['main.tf', 'resource "aws_s3_bucket" "x" { bucket = aws_account_id }']]);
+    expect(detectCloudHints(fc)).toContain('aws');
+  });
+});
+
+// ── fs-touching helper ──
+
+describe('detectExistingModules', () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'lace-workspace-tools-'));
+  });
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  test('reads .lace/main.tf and extracts source = "..." entries', () => {
+    const laceDir = join(tmpRoot, '.lace');
+    mkdirSync(laceDir);
+    writeFileSync(
+      join(laceDir, 'main.tf'),
+      [
+        'module "vpc" {',
+        '  source  = "terraform-aws-modules/vpc/aws"',
+        '  version = "5.0"',
+        '}',
+        'module "iam" {',
+        '  source = "../local-iam"',
+        '}',
+      ].join('\n'),
+    );
+
+    expect(detectExistingModules(tmpRoot)).toEqual([
+      'terraform-aws-modules/vpc/aws',
+      '../local-iam',
+    ]);
+  });
+
+  test('returns [] when .lace/ does not exist', () => {
+    expect(detectExistingModules(tmpRoot)).toEqual([]);
+  });
+
+  test('returns [] when .lace/main.tf is missing (e.g. only state.lace exists)', () => {
+    mkdirSync(join(tmpRoot, '.lace'));
+    expect(detectExistingModules(tmpRoot)).toEqual([]);
+  });
+});
+
+// ── Composition ──
+
+describe('buildProjectProfile', () => {
+  let tmpRoot: string;
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'lace-workspace-profile-'));
+  });
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  test('composes detection helpers + fs read', () => {
+    // Set up an .lace/main.tf so existing_modules is non-empty.
+    const laceDir = join(tmpRoot, '.lace');
+    mkdirSync(laceDir);
+    writeFileSync(join(laceDir, 'main.tf'), 'module "vpc" { source = "aws-modules/vpc" }');
+
+    const profile = buildProjectProfile(
+      tmpRoot,
+      new Set(['package.json', 'Dockerfile']),
+      new Map([
+        ['package.json', '{"dependencies":{"express":"*"},"engines":{"node":">=18"}}'],
+        ['Dockerfile', 'FROM node:20\n'],
+      ]),
+    );
+
+    expect(profile).toEqual({
+      languages: ['typescript/javascript'],
+      frameworks: ['express'],
+      runtimes: ['node:20', 'node:>=18'],
+      databases: [],
+      cloud_hints: [],
+      existing_modules: ['aws-modules/vpc'],
+    });
+  });
+
+  test('empty workspace yields all-empty profile', () => {
+    expect(buildProjectProfile(tmpRoot, new Set(), new Map())).toEqual({
+      languages: [],
+      frameworks: [],
+      runtimes: [],
+      databases: [],
+      cloud_hints: [],
+      existing_modules: [],
+    });
+  });
+});

--- a/packages/chat-sidebar/src/host/tools/workspace-tools.ts
+++ b/packages/chat-sidebar/src/host/tools/workspace-tools.ts
@@ -34,8 +34,13 @@ const MAX_FILE_BYTES = 4096;
 const MAX_CONTEXT_FILES = 8;
 
 // ── Project Profile ──
+//
+// Detection helpers exported for unit testing. Composed in
+// `buildProjectProfile`. Pure data functions (`detect*` from
+// `Set`/`Map` inputs) plus one fs-touching helper
+// (`detectExistingModules`) that takes the workspace root.
 
-type ProjectProfile = {
+export type ProjectProfile = {
   languages: string[];
   frameworks: string[];
   runtimes: string[];
@@ -44,7 +49,7 @@ type ProjectProfile = {
   existing_modules: string[];
 };
 
-function detectLanguages(found: Set<string>): string[] {
+export function detectLanguages(found: Set<string>): string[] {
   const langs: string[] = [];
   if (found.has('package.json')) langs.push('typescript/javascript');
   if (found.has('go.mod')) langs.push('go');
@@ -55,7 +60,7 @@ function detectLanguages(found: Set<string>): string[] {
   return langs;
 }
 
-function detectFrameworks(fileContents: Map<string, string>): string[] {
+export function detectFrameworks(fileContents: Map<string, string>): string[] {
   const frameworks: string[] = [];
   const pkg = fileContents.get('package.json');
   if (pkg) {
@@ -88,7 +93,7 @@ function detectFrameworks(fileContents: Map<string, string>): string[] {
   return frameworks;
 }
 
-function detectRuntimes(fileContents: Map<string, string>): string[] {
+export function detectRuntimes(fileContents: Map<string, string>): string[] {
   const runtimes: string[] = [];
   const dockerfile = fileContents.get('Dockerfile') ?? fileContents.get('docker-compose.yml') ?? '';
   const fromMatch = dockerfile.match(/^FROM\s+(\S+)/m);
@@ -106,7 +111,7 @@ function detectRuntimes(fileContents: Map<string, string>): string[] {
   return runtimes;
 }
 
-function detectDatabases(fileContents: Map<string, string>): string[] {
+export function detectDatabases(fileContents: Map<string, string>): string[] {
   const dbs: string[] = [];
   const allContent = [...fileContents.values()].join('\n').toLowerCase();
   if (/postgres|pg|psycopg/i.test(allContent)) dbs.push('postgres');
@@ -117,7 +122,7 @@ function detectDatabases(fileContents: Map<string, string>): string[] {
   return [...new Set(dbs)];
 }
 
-function detectCloudHints(fileContents: Map<string, string>): string[] {
+export function detectCloudHints(fileContents: Map<string, string>): string[] {
   const hints: string[] = [];
   const allContent = [...fileContents.values()].join('\n');
   if (/aws-sdk|@aws-sdk|amazonaws\.com|aws_/i.test(allContent)) hints.push('aws');
@@ -126,7 +131,7 @@ function detectCloudHints(fileContents: Map<string, string>): string[] {
   return [...new Set(hints)];
 }
 
-function detectExistingModules(root: string): string[] {
+export function detectExistingModules(root: string): string[] {
   const laceDir = path.join(root, '.lace');
   const modules: string[] = [];
   try {
@@ -141,7 +146,7 @@ function detectExistingModules(root: string): string[] {
   return modules;
 }
 
-function buildProjectProfile(
+export function buildProjectProfile(
   root: string,
   found: Set<string>,
   fileContents: Map<string, string>,


### PR DESCRIPTION
## Summary

Closes the test gap PR A flagged. chat-sidebar's VS Code adapter modules had zero test coverage. Adds 44 new tests across 3 files. Total chat-sidebar suite: **24 → 68**.

**Coverage:**
- \`vscode-part-codec\` (13) — toVscodeMessage, vscodeStreamToEvents, abortSignalToToken, vscodePartToCore. Pure conversion + edge cases.
- \`vscode-webview-transport\` (3) — postMessage forwards, onMessage subscribes, dispose unsubscribes. Uses real \`@lace-cloud/chat-core\` message types.
- \`workspace-tools\` (28) — every detector helper isolated + composition. Small refactor: detection helpers + ProjectProfile type now exported (were file-local). No behaviour change.

**Test infra:** new \`packages/chat-sidebar/src/__tests__/test-utils/vscode-mock.ts\` shared factory. Each test file installs via async \`vi.mock('vscode', async () => ...)\` to avoid static-import hoisting issues.

**Still untested (out of scope — integration territory):**
- vscode-adapter.ts (vscode.lm.selectChatModels + sendRequest)
- host/controller.ts (wires adapter + AgentController + tools + Subscribe + workspaceState)
- host/view-provider.ts (WebviewViewProvider integration)

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test:unit\` 68/68
- [x] \`pnpm test:host-e2e\` 10/10
- [x] \`pnpm build\` 3 bundles compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)