### PR TITLE
fix(release): grant packages:read for @lace-cloud/* from GH Packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,8 @@ on:
     branches: [main]
 
 permissions:
-  contents: write  # Required to create tags and releases
+  contents: write   # Required to create tags and releases
+  packages: read    # Required to fetch @lace-cloud/* from GH Packages
 
 jobs:
   version-bumped:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lace-cloud",
   "displayName": "Lace Cloud",
   "description": "",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "packageManager": "pnpm@10.29.3",
   "publisher": "LaceCloudInc",
   "repository": {


### PR DESCRIPTION
Hotfix: post-PR-103 release.yml run failed at `pnpm install` with 403 from npm.pkg.github.com. The workflow's `permissions: contents: write` block restricted GITHUB_TOKEN's scopes — adding `packages: read` unblocks the GH Packages fetch.

Once merged through develop → main, re-run the failed release workflow to ship v0.0.30.