### PR TITLE
v0.0.31 — release.yml packages:read hotfix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,8 @@ on:
     branches: [main]
 
 permissions:
-  contents: write  # Required to create tags and releases
+  contents: write   # Required to create tags and releases
+  packages: read    # Required to fetch @lace-cloud/* from GH Packages
 
 jobs:
   version-bumped:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lace-cloud",
   "displayName": "Lace Cloud",
   "description": "",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "packageManager": "pnpm@10.29.3",
   "publisher": "LaceCloudInc",
   "repository": {


### PR DESCRIPTION
Promotes #105 to main. v0.0.31 supersedes v0.0.30 (whose release.yml run failed on a missing packages:read scope before tag creation). Push to main fires the now-fixed release.yml: marketplace publish + tag v0.0.31 + GitHub Release.