### PR TITLE
Arc P10 E1: consume BundleStateEvent + single ApplyAction

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,11 +189,14 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.12.6",
-    "@lace-cloud/canvas": "^0.1.1",
-    "@lace-cloud/chat-webview": "^0.1.1",
-    "@lace-cloud/design-tokens": "^0.1.1",
-    "@lace-cloud/host": "^0.1.1",
+    "@lace-cloud/canvas": "0.1.1-next.24828814947",
+    "@lace-cloud/chat-core": "0.1.1-next.24828814947",
     "@lace-cloud/chat-sidebar": "workspace:*",
+    "@lace-cloud/chat-webview": "0.1.1-next.24828814947",
+    "@lace-cloud/design-tokens": "0.1.1-next.24828814947",
+    "@lace-cloud/host": "0.1.1-next.24828814947",
+    "@lace-cloud/proto": "0.1.1-next.24828814947",
+    "@lace-cloud/ui": "0.1.1-next.24828814947",
     "@xyflow/react": "^12.10.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/packages/chat-sidebar/package.json
+++ b/packages/chat-sidebar/package.json
@@ -9,11 +9,11 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@lace-cloud/chat-core": "^0.1.1",
-    "@lace-cloud/chat-webview": "^0.1.1",
-    "@lace-cloud/design-tokens": "^0.1.1",
-    "@lace-cloud/host": "^0.1.1",
-    "@lace-cloud/proto": "^0.1.1",
+    "@lace-cloud/chat-core": "0.1.1-next.24828814947",
+    "@lace-cloud/chat-webview": "0.1.1-next.24828814947",
+    "@lace-cloud/design-tokens": "0.1.1-next.24828814947",
+    "@lace-cloud/host": "0.1.1-next.24828814947",
+    "@lace-cloud/proto": "0.1.1-next.24828814947",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/packages/chat-sidebar/src/__tests__/chat-tools.test.ts
+++ b/packages/chat-sidebar/src/__tests__/chat-tools.test.ts
@@ -1,34 +1,31 @@
 import { createToolRegistry, type ToolRegistry } from '@lace-cloud/chat-core';
 import type { LaceTransport, RegistryModule, RenderError } from '@lace-cloud/host';
+import type { CanvasView } from '@lace-cloud/proto';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { type GenerateToolDeps, registerGenerateTools } from '../host/tools/generate-tools';
 import { registerGraphReadTools } from '../host/tools/graph-read-tools';
 import { type GraphWriteDeps, registerGraphWriteTools } from '../host/tools/graph-write-tools';
 import { makeCanvasView, makeEdge, makeNode } from './helpers';
 
-// ── Mock RPC client ──
+// ── Mock RPC client (post-P10: single applyAction surface + read queries) ──
 
 function makeMockClient(overrides: Record<string, unknown> = {}) {
   return {
-    placeModule: vi
-      .fn()
-      .mockResolvedValue(makeCanvasView([makeNode('vpc', 'module', 'aws/vpc@v1.0.0')])),
+    applyAction: vi.fn().mockResolvedValue({ success: true, errors: [] }),
     inspectModule: vi.fn().mockResolvedValue({
       name: 'aws/vpc',
       system: 'aws',
       version: 'v1.0.0',
       module_interface: { inputs: [], outputs: [] },
     }),
-    updateInput: vi.fn().mockResolvedValue(makeCanvasView([makeNode('vpc')])),
-    autoConnect: vi
-      .fn()
-      .mockResolvedValue(
-        makeCanvasView(
-          [makeNode('vpc'), makeNode('subnet')],
-          [makeEdge('vpc', 'subnet', 'vpc_id', 'vpc_id')],
-        ),
-      ),
-    syncLayout: vi.fn().mockResolvedValue({}),
+    queryNodeConfig: vi.fn().mockResolvedValue({
+      instance_id: 'vpc',
+      inputs: [],
+      outputs: [],
+      sibling_ids: [],
+      depends_on: [],
+      available_variables: [],
+    }),
     queryValidate: vi.fn().mockResolvedValue({ errors: [] as RenderError[] }),
     querySettings: vi.fn().mockResolvedValue({
       terraform: { required_version: '', required_providers: [] },
@@ -36,14 +33,21 @@ function makeMockClient(overrides: Record<string, unknown> = {}) {
       locals: [],
       environments: {},
     }),
-    setLocals: vi.fn().mockResolvedValue(makeCanvasView([makeNode('vpc')])),
-    setEnvironments: vi.fn().mockResolvedValue({}),
     sessionGenerate: vi.fn().mockResolvedValue({
       files_written: ['main.tf'],
       diagnostics: [],
     }),
     ...overrides,
   };
+}
+
+/**
+ * Next-view stub for tests: tools that call `applyActionAndAwaitView`
+ * receive this view after the applyAction mock resolves. Tests that
+ * need to inspect the post-mutation view override this per-assertion.
+ */
+function makeAwaitNextView(view: CanvasView | null) {
+  return () => Promise.resolve(view);
 }
 
 // ── Registry module fixtures ──
@@ -80,13 +84,16 @@ const testModules: RegistryModule[] = [
 let mockClient: ReturnType<typeof makeMockClient>;
 let registry: ToolRegistry;
 
-function makeWriteDeps(): GraphWriteDeps {
+function makeWriteDeps(
+  nextView: CanvasView | null = makeCanvasView([makeNode('vpc', 'module', 'aws/vpc@v1.0.0')]),
+): GraphWriteDeps {
   mockClient = makeMockClient();
   return {
     getRpcClient: () => mockClient as unknown as LaceTransport,
     getRegistryModules: () => testModules,
     getUserOrgs: () => [],
     getCanvasView: () => null,
+    awaitNextView: makeAwaitNextView(nextView),
   };
 }
 
@@ -102,20 +109,22 @@ describe('write tools', () => {
   });
 
   describe('lace_add_module', () => {
-    test('adds module by exact name via placeModule RPC', async () => {
+    test('adds module by exact name via applyAction RPC', async () => {
       const handler = registry.getHandler('lace_add_module')!;
       const result = await handler({ name: 'aws/vpc' });
 
       expect(result.isError).toBeFalsy();
       expect(result.content).toContain('aws/vpc');
       expect(result.content).toContain('instance **"vpc"**');
-      expect(mockClient.placeModule).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: 'aws/vpc',
-          system: 'aws',
-          version: 'v1.0.0',
-        }),
-      );
+      expect(mockClient.applyAction).toHaveBeenCalledWith([
+        {
+          place_module: expect.objectContaining({
+            name: 'aws/vpc',
+            system: 'aws',
+            version: 'v1.0.0',
+          }),
+        },
+      ]);
     });
 
     test('resolves single fuzzy match', async () => {
@@ -124,13 +133,15 @@ describe('write tools', () => {
 
       expect(result.isError).toBeFalsy();
       expect(result.content).toContain('azure/resource-group');
-      expect(mockClient.placeModule).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: 'azure/resource-group',
-          system: 'azure',
-          version: 'v2.0.0',
-        }),
-      );
+      expect(mockClient.applyAction).toHaveBeenCalledWith([
+        {
+          place_module: expect.objectContaining({
+            name: 'azure/resource-group',
+            system: 'azure',
+            version: 'v2.0.0',
+          }),
+        },
+      ]);
     });
 
     test('disambiguates multiple fuzzy matches', async () => {
@@ -141,15 +152,14 @@ describe('write tools', () => {
       expect(result.content).toContain('Multiple modules match');
       expect(result.content).toContain('aws/vpc');
       expect(result.content).toContain('aws/subnet');
-      expect(mockClient.placeModule).not.toHaveBeenCalled();
+      expect(mockClient.applyAction).not.toHaveBeenCalled();
     });
 
     test('passes org provenance when module found in user org', async () => {
-      // Simulate: private module not in local cache, found via RPC in org
       mockClient = makeMockClient({
         listRegistryModules: vi
           .fn()
-          .mockResolvedValueOnce({ modules: [] }) // public: not found
+          .mockResolvedValueOnce({ modules: [] })
           .mockResolvedValueOnce({
             modules: [
               {
@@ -164,9 +174,12 @@ describe('write tools', () => {
 
       const deps: GraphWriteDeps = {
         getRpcClient: () => mockClient as unknown as LaceTransport,
-        getRegistryModules: () => [], // empty local cache — forces RPC search
+        getRegistryModules: () => [],
         getUserOrgs: () => [{ slug: 'acme-corp', name: 'Acme Corp', role: 'member' }],
         getCanvasView: () => null,
+        awaitNextView: makeAwaitNextView(
+          makeCanvasView([makeNode('custom-networking', 'module', 'aws/custom-networking@v1.0.0')]),
+        ),
       };
       registry = createToolRegistry();
       registerGraphWriteTools(registry, deps);
@@ -179,13 +192,16 @@ describe('write tools', () => {
       const result = await handler({ name: 'aws/custom-networking' });
 
       expect(result.isError).toBeFalsy();
-      expect(mockClient.placeModule).toHaveBeenCalledWith(
-        expect.objectContaining({ organization: 'acme-corp' }),
-      );
+      expect(mockClient.applyAction).toHaveBeenCalledWith([
+        { place_module: expect.objectContaining({ organization: 'acme-corp' }) },
+      ]);
     });
 
-    test('surfaces engine error when placeModule fails', async () => {
-      mockClient.placeModule.mockRejectedValue(new Error('module not found in registry'));
+    test('surfaces engine error when applyAction rejects', async () => {
+      mockClient.applyAction.mockResolvedValue({
+        success: false,
+        errors: [{ instance_id: '', input_name: '', message: 'module not found in registry' }],
+      });
       const handler = registry.getHandler('lace_add_module')!;
       const result = await handler({ name: 'aws/vpc' });
 
@@ -205,14 +221,15 @@ describe('write tools', () => {
 
       expect(result.isError).toBeFalsy();
       expect(result.content).toContain('literal true');
-      expect(mockClient.updateInput).toHaveBeenCalledWith({
-        instance_id: 'vpc',
-        input_name: 'enable_dns',
-        mode: 'literal',
-        value: true,
-        variable: undefined,
-        expression: undefined,
-      });
+      expect(mockClient.applyAction).toHaveBeenCalledWith([
+        {
+          update_input: expect.objectContaining({
+            instance_id: 'vpc',
+            input_name: 'enable_dns',
+            value: true,
+          }),
+        },
+      ]);
     });
 
     test('sets variable reference', async () => {
@@ -225,14 +242,15 @@ describe('write tools', () => {
 
       expect(result.isError).toBeFalsy();
       expect(result.content).toContain('variable "vpc_cidr"');
-      expect(mockClient.updateInput).toHaveBeenCalledWith({
-        instance_id: 'vpc',
-        input_name: 'cidr_block',
-        mode: 'variable',
-        value: undefined,
-        variable: 'vpc_cidr',
-        expression: undefined,
-      });
+      expect(mockClient.applyAction).toHaveBeenCalledWith([
+        {
+          update_input: expect.objectContaining({
+            instance_id: 'vpc',
+            input_name: 'cidr_block',
+            variable: 'vpc_cidr',
+          }),
+        },
+      ]);
     });
 
     test('returns error when no binding type provided', async () => {
@@ -272,6 +290,12 @@ describe('generate tools', () => {
       getRpcClient: () => mockClient as unknown as LaceTransport,
       getLaceDir: () => '/tmp/test-workspace/.lace',
       getCanvasView: () => null,
+      awaitNextView: makeAwaitNextView(
+        makeCanvasView(
+          [makeNode('vpc'), makeNode('subnet')],
+          [makeEdge('vpc', 'subnet', 'vpc_id', 'vpc_id')],
+        ),
+      ),
     };
     registerGenerateTools(registry, deps);
   });
@@ -287,16 +311,21 @@ describe('generate tools', () => {
       expect(result.isError).toBeFalsy();
       expect(result.content).toContain('Auto-connected 1 wire(s)');
       expect(result.content).toContain('vpc.vpc_id');
-      expect(mockClient.autoConnect).toHaveBeenCalledWith({
-        source: 'vpc',
-        target: 'subnet',
-      });
+      expect(mockClient.applyAction).toHaveBeenCalledWith([
+        { auto_connect: { source: 'vpc', target: 'subnet' } },
+      ]);
     });
 
     test('reports no match when no edges returned', async () => {
-      mockClient.autoConnect.mockResolvedValue(
-        makeCanvasView([makeNode('vpc'), makeNode('subnet')]),
-      );
+      mockClient = makeMockClient();
+      registry = createToolRegistry();
+      const deps: GenerateToolDeps = {
+        getRpcClient: () => mockClient as unknown as LaceTransport,
+        getLaceDir: () => '/tmp/test-workspace/.lace',
+        getCanvasView: () => null,
+        awaitNextView: makeAwaitNextView(makeCanvasView([makeNode('vpc'), makeNode('subnet')])),
+      };
+      registerGenerateTools(registry, deps);
       const handler = registry.getHandler('lace_auto_connect')!;
       const result = await handler({
         source_instance: 'vpc',
@@ -343,6 +372,7 @@ describe('generate tools', () => {
         getRpcClient: () => mockClient as unknown as LaceTransport,
         getLaceDir: () => undefined,
         getCanvasView: () => null,
+        awaitNextView: makeAwaitNextView(null),
       };
       registry = createToolRegistry();
       registerGenerateTools(registry, deps);
@@ -372,9 +402,19 @@ describe('settings tools', () => {
       expect(result.content).toContain('region');
       expect(result.content).toContain('us-east-1');
       expect(mockClient.querySettings).toHaveBeenCalled();
-      expect(mockClient.setLocals).toHaveBeenCalledWith({
-        locals: [{ name: 'region', mode: 'literal', value: 'us-east-1', expression: undefined }],
-      });
+      expect(mockClient.applyAction).toHaveBeenCalledWith([
+        {
+          set_locals: {
+            locals: [
+              expect.objectContaining({
+                name: 'region',
+                mode: 'literal',
+                value: 'us-east-1',
+              }),
+            ],
+          },
+        },
+      ]);
     });
 
     test('sets expression local', async () => {
@@ -383,11 +423,19 @@ describe('settings tools', () => {
 
       expect(result.isError).toBeFalsy();
       expect(result.content).toContain('expression');
-      expect(mockClient.setLocals).toHaveBeenCalledWith({
-        locals: [
-          { name: 'prefix', mode: 'expression', value: undefined, expression: 'var.project' },
-        ],
-      });
+      expect(mockClient.applyAction).toHaveBeenCalledWith([
+        {
+          set_locals: {
+            locals: [
+              expect.objectContaining({
+                name: 'prefix',
+                mode: 'expression',
+                expression: 'var.project',
+              }),
+            ],
+          },
+        },
+      ]);
     });
 
     test('returns error when neither value nor expression provided', async () => {
@@ -411,9 +459,13 @@ describe('settings tools', () => {
       expect(result.content).toContain('staging');
       expect(result.content).toContain('region');
       expect(mockClient.querySettings).toHaveBeenCalled();
-      expect(mockClient.setEnvironments).toHaveBeenCalledWith({
-        environments: { staging: { region: 'us-west-2', instance_type: 't3.small' } },
-      });
+      expect(mockClient.applyAction).toHaveBeenCalledWith([
+        {
+          set_environments: expect.objectContaining({
+            environments: { staging: { region: 'us-west-2', instance_type: 't3.small' } },
+          }),
+        },
+      ]);
     });
 
     test('returns error when environment name missing', async () => {

--- a/packages/chat-sidebar/src/host/controller.ts
+++ b/packages/chat-sidebar/src/host/controller.ts
@@ -3,9 +3,11 @@
 //
 // Responsibilities here — and only here:
 //   1. Build the VS Code adapter + webview transport.
-//   2. Maintain the latest CanvasView by consuming the engine's
-//      Subscribe stream (so tools can read it synchronously via
-//      `deps.getCanvasView`).
+//   2. Consume the engine's Subscribe stream (BundleStateEvent), project
+//      BundleState locally into a CanvasView, and expose both:
+//        - `getCanvasView()` — synchronous snapshot of the latest view
+//        - `awaitNextView()` — promise resolving on the next state update
+//      so tools can read synchronously or wait for post-mutation state.
 //   3. Own the engine session lifecycle for the chat (open session,
 //      refresh context summary, mount proactivity).
 //   4. Register the VS Code-side tool set on a per-instance
@@ -13,8 +15,7 @@
 //   5. Delegate the agentic loop to `AgentController` from chat-core.
 //
 // No agentic-loop logic, no message codecs, no rule evaluation. Those
-// live in chat-core. When we port to JetBrains, this file is the
-// shape the JetBrains controller mirrors — the rest is unchanged.
+// live in chat-core.
 
 import {
   AgentController,
@@ -24,8 +25,10 @@ import {
   ProactivityWatcher,
   type ToolRegistry,
 } from '@lace-cloud/chat-core';
-import type { CanvasView, EngineEvent, LaceTransport, RegistryModule } from '@lace-cloud/host';
-import { convertCanvasView } from '@lace-cloud/host';
+import type { BundleState, LaceTransport, RegistryModule } from '@lace-cloud/host';
+import { SubscribeHandler } from '@lace-cloud/host';
+import type { CanvasView } from '@lace-cloud/proto';
+import { parseModuleKey, projectCanvasView } from '@lace-cloud/proto';
 import * as vscode from 'vscode';
 import { createVsCodeChatAdapter } from '../vscode-adapter';
 import { createVsCodeWebviewTransport } from '../vscode-webview-transport';
@@ -49,8 +52,9 @@ export class ChatController {
   private readonly agent: AgentController;
   private readonly outputChannel: vscode.OutputChannel;
   private latestView: CanvasView | null = null;
-  private subscribeHandler: ReturnType<LaceTransport['subscribeStream']> | null = null;
+  private subscribeHandler: SubscribeHandler | null = null;
   private proactivity: ProactivityWatcher | null = null;
+  private stateUpdateWaiters: Array<(view: CanvasView | null) => void> = [];
 
   constructor(
     context: vscode.ExtensionContext,
@@ -94,10 +98,13 @@ export class ChatController {
 
   dispose(): void {
     this.agent.dispose();
-    this.subscribeHandler?.cancel();
+    this.subscribeHandler?.stop();
     this.subscribeHandler = null;
     this.proactivity?.stop();
     this.proactivity = null;
+    // Reject any pending awaiters so callers don't hang on dispose.
+    for (const resolve of this.stateUpdateWaiters) resolve(null);
+    this.stateUpdateWaiters = [];
   }
 
   async clearHistory(): Promise<void> {
@@ -108,12 +115,26 @@ export class ChatController {
     return this.latestView;
   }
 
+  /**
+   * Returns a promise that resolves on the NEXT BundleState arrival on
+   * the Subscribe stream (with the newly-projected CanvasView, or null
+   * if the stream ended / errored before the next event). Tools that
+   * mutate state via applyAction call this BEFORE applyAction to set
+   * up the waiter, then await the promise AFTER applyAction returns.
+   */
+  awaitNextView(): Promise<CanvasView | null> {
+    return new Promise((resolve) => {
+      this.stateUpdateWaiters.push(resolve);
+    });
+  }
+
   // ── Private ──
 
   private registerTools(): void {
     const deps = {
       ...this.externalDeps,
       getCanvasView: () => this.latestView,
+      awaitNextView: () => this.awaitNextView(),
     };
     registerRegistryTools(this.registry, deps);
     registerGraphReadTools(this.registry, deps);
@@ -126,10 +147,6 @@ export class ChatController {
     if (this.subscribeHandler) return;
     const transport = this.externalDeps.getRpcClient();
     if (!transport?.sessionId) {
-      // Attempt a lazy session-open so the Subscribe stream is
-      // available from the first turn. If no workspace is open or
-      // the engine isn't running, the runTurn path surfaces the
-      // error to the webview.
       void this.ensureSession().then(() => this.openSubscribe());
       return;
     }
@@ -145,10 +162,11 @@ export class ChatController {
     const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
     if (!laceDir || !workspaceFolder) return null;
 
-    const { session_id } = await transport.sessionOpen({
+    const { session_id, state } = await transport.sessionOpen({
       file_path: laceDir,
       workspace_name: workspaceFolder.name,
     });
+    this.adoptState(state);
     return session_id;
   }
 
@@ -159,15 +177,20 @@ export class ChatController {
       return;
     }
 
-    this.subscribeHandler = transport.subscribeStream(transport.sessionId);
-    this.subscribeHandler.on('data', (event: EngineEvent) => this.handleEngineEvent(event));
-    this.subscribeHandler.on('end', () => {
-      this.subscribeHandler = null;
-    });
-    this.subscribeHandler.on('error', () => {
-      this.subscribeHandler = null;
-      // Avoid tight retry loops — if the engine dies mid-session, the
-      // next user turn will attempt to re-establish the session.
+    this.subscribeHandler = new SubscribeHandler();
+    this.subscribeHandler.start(transport.subscribeStream(transport.sessionId), {
+      onStateUpdated: (state) => this.adoptState(state),
+      onGenerateProgress: () => {},
+      onGenerateSuccess: () => {},
+      onGenerateError: () => {},
+      onEnd: () => {
+        this.subscribeHandler = null;
+      },
+      onError: () => {
+        this.subscribeHandler = null;
+        // Avoid tight retry loops — if the engine dies mid-session, the
+        // next user turn will attempt to re-establish the session.
+      },
     });
 
     this.proactivity = new ProactivityWatcher({
@@ -183,11 +206,21 @@ export class ChatController {
     this.proactivity.start();
   }
 
-  private handleEngineEvent(event: EngineEvent): void {
-    if (event.state_updated?.view) {
-      this.latestView = convertCanvasView(event.state_updated.view);
-      this.postContextSummary();
-    }
+  private adoptState(state: BundleState): void {
+    if (!state.bundle) return;
+    const { id: moduleName } = parseModuleKey(state.bundle.entry);
+    const view = projectCanvasView(state.bundle, state.layouts ?? {}, {
+      moduleName,
+      canUndo: state.can_undo,
+      canRedo: state.can_redo,
+      isDirty: state.is_dirty,
+    });
+    this.latestView = view;
+    this.postContextSummary();
+
+    const waiters = this.stateUpdateWaiters;
+    this.stateUpdateWaiters = [];
+    for (const resolve of waiters) resolve(view);
   }
 
   private postContextSummary(): void {

--- a/packages/chat-sidebar/src/host/tools/generate-tools.ts
+++ b/packages/chat-sidebar/src/host/tools/generate-tools.ts
@@ -4,13 +4,15 @@
 // All operations go through RPC to the CLI.
 
 import type { ToolRegistry, ToolResult } from '@lace-cloud/chat-core';
-import type { CanvasView, LaceTransport } from '@lace-cloud/host';
-import { errorMessage, requireEngine } from './helpers';
+import type { LaceTransport } from '@lace-cloud/host';
+import type { CanvasView } from '@lace-cloud/proto';
+import { applyActionAndAwaitView, applyReason, errorMessage, requireEngine } from './helpers';
 
 export type GenerateToolDeps = {
   getRpcClient: () => LaceTransport | null;
   getLaceDir: () => string | undefined;
   getCanvasView: () => CanvasView | null;
+  awaitNextView: () => Promise<CanvasView | null>;
 };
 
 export function registerGenerateTools(registry: ToolRegistry, deps: GenerateToolDeps): void {
@@ -49,13 +51,17 @@ export function registerGenerateTools(registry: ToolRegistry, deps: GenerateTool
       if ('error' in engineResult) return engineResult.error;
 
       try {
-        const canvasView = await engineResult.client.autoConnect({
-          source: sourceInstance,
-          target: targetInstance,
-        });
+        const { result, view } = await applyActionAndAwaitView(
+          engineResult.client,
+          { auto_connect: { source: sourceInstance, target: targetInstance } },
+          deps.awaitNextView,
+        );
+        if (!result.success) {
+          return { content: `Failed to auto-connect: ${applyReason(result)}`, isError: true };
+        }
 
         // Count new edges involving these instances
-        const relevantEdges = canvasView.edges.filter(
+        const relevantEdges = (view?.edges ?? []).filter(
           (e) => e.source === sourceInstance && e.target === targetInstance,
         );
 

--- a/packages/chat-sidebar/src/host/tools/graph-read-tools.ts
+++ b/packages/chat-sidebar/src/host/tools/graph-read-tools.ts
@@ -4,7 +4,8 @@
 // All operations go through RPC to the CLI.
 
 import { formatCanvasState, type ToolRegistry, type ToolResult } from '@lace-cloud/chat-core';
-import type { CanvasView, LaceTransport } from '@lace-cloud/host';
+import type { LaceTransport } from '@lace-cloud/host';
+import type { CanvasView } from '@lace-cloud/proto';
 import { errorMessage, requireEngine } from './helpers';
 
 export type GraphReadDeps = {

--- a/packages/chat-sidebar/src/host/tools/graph-write-tools.ts
+++ b/packages/chat-sidebar/src/host/tools/graph-write-tools.ts
@@ -2,17 +2,26 @@
 //
 // Write tools: lace_add_module, lace_remove_module, lace_connect,
 // lace_disconnect, lace_set_input, lace_rename_instance, lace_set_variable, lace_undo.
-// All operations go through RPC to the CLI.
+// All mutations traverse the single ApplyAction RPC on the transport.
 
 import type { ToolRegistry, ToolResult } from '@lace-cloud/chat-core';
-import type { CanvasView, LaceTransport, RegistryModule } from '@lace-cloud/host';
-import { errorMessage, requireEngine } from './helpers';
+import type { LaceTransport, RegistryModule } from '@lace-cloud/host';
+import type { CanvasView } from '@lace-cloud/proto';
+import { modeToInputMode } from '@lace-cloud/proto';
+import {
+  applyAction,
+  applyActionAndAwaitView,
+  applyReason,
+  errorMessage,
+  requireEngine,
+} from './helpers';
 
 export type GraphWriteDeps = {
   getRpcClient: () => LaceTransport | null;
   getRegistryModules: () => RegistryModule[];
   getUserOrgs: () => Array<{ slug: string; name: string; role: string }>;
   getCanvasView: () => CanvasView | null;
+  awaitNextView: () => Promise<CanvasView | null>;
 };
 
 // ── Tool Registration ──
@@ -145,25 +154,35 @@ export function registerGraphWriteTools(registry: ToolRegistry, deps: GraphWrite
       if ('error' in engineResult) return engineResult.error;
 
       try {
-        // PlaceModule: single RPC — CLI fetches the bundle, places the module,
-        // and handles layout positioning server-side.
         const existingNodes = deps.getCanvasView()?.nodes ?? [];
         const existingIds = new Set(existingNodes.map((n) => n.id));
 
-        const canvasView = await engineResult.client.placeModule({
-          name: match.name,
-          system: match.system,
-          version: versionToAdd,
-          organization: matchOrg,
-        });
+        const { result, view } = await applyActionAndAwaitView(
+          engineResult.client,
+          {
+            place_module: {
+              name: match.name,
+              system: match.system,
+              version: versionToAdd,
+              organization: matchOrg ?? '',
+              position: undefined,
+            },
+          },
+          deps.awaitNextView,
+        );
 
-        const newNodes = canvasView.nodes.filter((n) => !existingIds.has(n.id));
+        if (!result.success) {
+          return {
+            content: `Failed to add module: ${applyReason(result)}`,
+            isError: true,
+          };
+        }
 
-        // Find the newly added instance ID — try module_key match first, then new node
+        const nodes = view?.nodes ?? [];
+        const newNodes = nodes.filter((n) => !existingIds.has(n.id));
         const instanceId =
-          canvasView.nodes.find((n) => n.module_key?.includes(match?.id))?.id ?? newNodes[0]?.id;
+          nodes.find((n) => n.module_key?.includes(match?.id ?? ''))?.id ?? newNodes[0]?.id;
 
-        // Build response with required inputs so model can set them immediately
         const lines: string[] = [];
 
         if (instanceId) {
@@ -261,7 +280,15 @@ export function registerGraphWriteTools(registry: ToolRegistry, deps: GraphWrite
       }
 
       try {
-        await engineResult.client.deleteInstance({ instance_id: instanceId });
+        const result = await applyAction(engineResult.client, {
+          delete_instance: { instance_id: instanceId },
+        });
+        if (!result.success) {
+          return {
+            content: `Failed to remove instance: ${applyReason(result)}`,
+            isError: true,
+          };
+        }
 
         const lines = [`Removed instance "${instanceId}" from the canvas.`];
         if (warnLines.length > 0) {
@@ -334,21 +361,29 @@ export function registerGraphWriteTools(registry: ToolRegistry, deps: GraphWrite
       if ('error' in engineResult) return engineResult.error;
 
       try {
-        await engineResult.client.connect({
-          source: sourceInstance,
-          target: targetInstance,
-          source_output: sourceOutput,
-          target_input: targetInput,
+        const result = await applyAction(engineResult.client, {
+          connect: {
+            source: sourceInstance,
+            target: targetInstance,
+            source_output: sourceOutput,
+            target_input: targetInput,
+          },
         });
+        if (!result.success) {
+          const reason = applyReason(result);
+          const notFound =
+            reason.toLowerCase().includes('not found') || reason.toLowerCase().includes('unknown');
+          return {
+            content: `Failed to connect: ${reason}${notFound ? '\nUse lace_inspect_node on each instance to see exact output/input names. Instance IDs come from the canvas snapshot.' : ''}`,
+            isError: true,
+          };
+        }
         return {
           content: `Connected ${sourceInstance}.${sourceOutput} → ${targetInstance}.${targetInput}`,
         };
       } catch (err: unknown) {
-        const msg = errorMessage(err);
-        const notFound =
-          msg.toLowerCase().includes('not found') || msg.toLowerCase().includes('unknown');
         return {
-          content: `Failed to connect: ${msg}${notFound ? '\nUse lace_inspect_node on each instance to see exact output/input names. Instance IDs come from the canvas snapshot.' : ''}`,
+          content: `Failed to connect: ${errorMessage(err)}`,
           isError: true,
         };
       }
@@ -390,10 +425,12 @@ export function registerGraphWriteTools(registry: ToolRegistry, deps: GraphWrite
       if ('error' in engineResult) return engineResult.error;
 
       try {
-        await engineResult.client.disconnect({
-          target: targetInstance,
-          input_name: inputName,
+        const result = await applyAction(engineResult.client, {
+          disconnect: { target: targetInstance, input_name: inputName },
         });
+        if (!result.success) {
+          return { content: `Failed to disconnect: ${applyReason(result)}`, isError: true };
+        }
         return { content: `Disconnected input "${inputName}" on instance "${targetInstance}".` };
       } catch (err: unknown) {
         return { content: `Failed to disconnect: ${errorMessage(err)}`, isError: true };
@@ -456,8 +493,8 @@ export function registerGraphWriteTools(registry: ToolRegistry, deps: GraphWrite
 
       let mode: string;
       let value: unknown;
-      let variable: string | undefined;
-      let expression: string | undefined;
+      let variable = '';
+      let expression = '';
 
       if (hasValue) {
         mode = 'literal';
@@ -474,14 +511,19 @@ export function registerGraphWriteTools(registry: ToolRegistry, deps: GraphWrite
       if ('error' in engineResult) return engineResult.error;
 
       try {
-        await engineResult.client.updateInput({
-          instance_id: instanceId,
-          input_name: inputName,
-          mode,
-          value,
-          variable,
-          expression,
+        const result = await applyAction(engineResult.client, {
+          update_input: {
+            instance_id: instanceId,
+            input_name: inputName,
+            mode: modeToInputMode(mode),
+            value,
+            variable,
+            expression,
+          },
         });
+        if (!result.success) {
+          return { content: `Failed to set input: ${applyReason(result)}`, isError: true };
+        }
 
         const desc =
           mode === 'literal'
@@ -539,7 +581,15 @@ export function registerGraphWriteTools(registry: ToolRegistry, deps: GraphWrite
       if ('error' in engineResult) return engineResult.error;
 
       try {
-        await engineResult.client.renameInstance({ old_id: oldId, new_id: newId });
+        const result = await applyAction(engineResult.client, {
+          rename_instance: { old_id: oldId, new_id: newId },
+        });
+        if (!result.success) {
+          return {
+            content: `Failed to rename instance: ${applyReason(result)}`,
+            isError: true,
+          };
+        }
 
         const lines = [`Renamed instance "${oldId}" to "${newId}".`];
 
@@ -605,25 +655,30 @@ export function registerGraphWriteTools(registry: ToolRegistry, deps: GraphWrite
       }
 
       const required = typeof params.required === 'boolean' ? params.required : true;
-      const description = typeof params.description === 'string' ? params.description : undefined;
+      const description = typeof params.description === 'string' ? params.description : '';
       const defaultValue = params.default !== undefined ? params.default : undefined;
 
       const engineResult = requireEngine(deps.getRpcClient);
       if ('error' in engineResult) return engineResult.error;
 
-      // Get existing variables, update or add the one specified
       try {
-        await engineResult.client.setVariables({
-          variables: [
-            {
-              name: varName,
-              type: varType,
-              required,
-              description,
-              default: defaultValue,
-            },
-          ],
+        const result = await applyAction(engineResult.client, {
+          set_variables: {
+            variables: [
+              {
+                name: varName,
+                type: varType,
+                required,
+                description,
+                default_value: defaultValue,
+                validation: undefined,
+              },
+            ],
+          },
         });
+        if (!result.success) {
+          return { content: `Failed to set variable: ${applyReason(result)}`, isError: true };
+        }
 
         const reqLabel = required ? 'required' : 'optional';
         const defLabel =
@@ -654,9 +709,18 @@ export function registerGraphWriteTools(registry: ToolRegistry, deps: GraphWrite
       if ('error' in engineResult) return engineResult.error;
 
       try {
-        const canvasView = await engineResult.client.undo();
+        const { result, view } = await applyActionAndAwaitView(
+          engineResult.client,
+          { undo: {} },
+          deps.awaitNextView,
+        );
+        if (!result.success) {
+          return { content: `Failed to undo: ${applyReason(result)}`, isError: true };
+        }
+        const nodeCount = view?.nodes.length ?? 0;
+        const edgeCount = view?.edges.length ?? 0;
         return {
-          content: `Undone. Canvas now has ${canvasView.nodes.length} instance(s) and ${canvasView.edges.length} connection(s).`,
+          content: `Undone. Canvas now has ${nodeCount} instance(s) and ${edgeCount} connection(s).`,
         };
       } catch (err: unknown) {
         return { content: `Failed to undo: ${errorMessage(err)}`, isError: true };
@@ -708,16 +772,35 @@ export function registerGraphWriteTools(registry: ToolRegistry, deps: GraphWrite
       const client = engineResult.client;
 
       try {
-        // Read existing locals, merge, then write back (setLocals replaces the full array)
+        // Read existing locals, merge, then write back (set_locals replaces the full array).
+        // SettingsConfig exposes locals as { name, mode, value_display } (display form);
+        // set_locals' LocalEntry is { name, mode, value, variable, expression }. For
+        // other entries we're preserving, route value_display into the field matching
+        // the mode. Exact round-trip is imperfect for complex literals — a read-typed
+        // surface would be cleaner, but ships the write path correctly in the meantime.
         const settings = await client.querySettings();
-        const existingLocals = (settings.locals ?? []).filter((l) => l.name !== name);
+        const preserved = (settings.locals ?? [])
+          .filter((l) => l.name !== name)
+          .map((l) => ({
+            name: l.name,
+            mode: l.mode,
+            value: l.mode === 'literal' ? (l.value_display as unknown) : undefined,
+            variable: '',
+            expression: l.mode !== 'literal' ? l.value_display : '',
+          }));
         const newLocal = {
           name,
           mode: hasExpression ? 'expression' : 'literal',
           value: hasValue ? value : undefined,
-          expression: hasExpression ? expression : undefined,
+          variable: '',
+          expression: hasExpression ? (expression as string) : '',
         };
-        await client.setLocals({ locals: [...existingLocals, newLocal] });
+        const result = await applyAction(client, {
+          set_locals: { locals: [...preserved, newLocal] },
+        });
+        if (!result.success) {
+          return { content: `Failed to set local: ${applyReason(result)}`, isError: true };
+        }
 
         const display = hasExpression
           ? `expression \`${expression}\``
@@ -775,7 +858,12 @@ export function registerGraphWriteTools(registry: ToolRegistry, deps: GraphWrite
           ...existingEnvs,
           [environment]: { ...(existingEnvs[environment] ?? {}), ...variables },
         };
-        await client.setEnvironments({ environments: mergedEnvs });
+        const result = await applyAction(client, {
+          set_environments: { environments: mergedEnvs, environment_backends: {} },
+        });
+        if (!result.success) {
+          return { content: `Failed to set environment: ${applyReason(result)}`, isError: true };
+        }
 
         const keys = Object.keys(variables).join(', ');
         return {
@@ -829,12 +917,16 @@ export function registerGraphWriteTools(registry: ToolRegistry, deps: GraphWrite
 
       try {
         const existingGroupIds = new Set((deps.getCanvasView()?.groups ?? []).map((g) => g.id));
-        const canvasView = await engineResult.client.createGroup({
-          label,
-          node_ids: instanceIds,
-        });
+        const { result, view } = await applyActionAndAwaitView(
+          engineResult.client,
+          { create_group: { label, node_ids: instanceIds } },
+          deps.awaitNextView,
+        );
+        if (!result.success) {
+          return { content: `Failed to create group: ${applyReason(result)}`, isError: true };
+        }
 
-        const newGroup = canvasView.groups.find((g) => !existingGroupIds.has(g.id));
+        const newGroup = view?.groups.find((g) => !existingGroupIds.has(g.id));
         const groupId = newGroup?.id ?? 'unknown';
         return {
           content: `Created group "${label}" (id: ${groupId}) with ${instanceIds.length} instances: ${instanceIds.join(', ')}.`,
@@ -873,7 +965,12 @@ export function registerGraphWriteTools(registry: ToolRegistry, deps: GraphWrite
       if ('error' in engineResult) return engineResult.error;
 
       try {
-        await engineResult.client.deleteGroup({ group_id: groupId });
+        const result = await applyAction(engineResult.client, {
+          delete_group: { group_id: groupId },
+        });
+        if (!result.success) {
+          return { content: `Failed to ungroup: ${applyReason(result)}`, isError: true };
+        }
         return { content: `Removed group "${groupId}". All instances remain on the canvas.` };
       } catch (err: unknown) {
         return { content: `Failed to ungroup: ${errorMessage(err)}`, isError: true };

--- a/packages/chat-sidebar/src/host/tools/helpers.ts
+++ b/packages/chat-sidebar/src/host/tools/helpers.ts
@@ -3,7 +3,8 @@
 // Shared helpers for chat tool implementations.
 
 import type { ToolResult } from '@lace-cloud/chat-core';
-import type { LaceTransport } from '@lace-cloud/host';
+import type { Action, BundleApplyResult, LaceTransport } from '@lace-cloud/host';
+import type { CanvasView } from '@lace-cloud/proto';
 
 const ENGINE_NOT_RUNNING: ToolResult = {
   content:
@@ -27,4 +28,50 @@ export function requireEngine(
 /** Extract error message from unknown error. */
 export function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Apply a single action through the single ApplyAction RPC. Post-P10 this
+ * is the only mutation surface; per-method transport helpers no longer
+ * exist. Returns the BundleApplyResult (success flag + validation errors).
+ */
+export async function applyAction(
+  client: LaceTransport,
+  action: Action,
+): Promise<BundleApplyResult> {
+  return client.applyAction([action]);
+}
+
+/**
+ * Apply an action, then wait for the post-mutation BundleState to arrive
+ * on the Subscribe stream (via ChatController.awaitNextView). Used by
+ * tools that must observe the post-mutation view (e.g., placeModule
+ * finding the new instance's id). The caller must wire `awaitNextView`
+ * through deps; it's set up before the RPC so no event is missed.
+ *
+ * On mutation failure, the waiter is discarded and the call short-circuits
+ * with `{ success: false, errors, view: null }` — there is no
+ * post-mutation state to wait for.
+ */
+export async function applyActionAndAwaitView(
+  client: LaceTransport,
+  action: Action,
+  awaitNextView: () => Promise<CanvasView | null>,
+): Promise<{ result: BundleApplyResult; view: CanvasView | null }> {
+  // Arm the waiter BEFORE sending the action — if we armed after, a
+  // fast Subscribe broadcast could arrive before the waiter is in the
+  // queue and we'd hang.
+  const viewPromise = awaitNextView();
+  const result = await applyAction(client, action);
+  if (!result.success) {
+    return { result, view: null };
+  }
+  const view = await viewPromise;
+  return { result, view };
+}
+
+/** Format a BundleApplyResult's errors as a human-readable reason. */
+export function applyReason(result: BundleApplyResult): string {
+  if (result.success) return '';
+  return result.errors.map((e) => e.message).join('; ') || 'unknown validation error';
 }

--- a/packages/chat-sidebar/src/host/view-provider.ts
+++ b/packages/chat-sidebar/src/host/view-provider.ts
@@ -1,5 +1,5 @@
 import * as path from 'node:path';
-import type { CanvasView } from '@lace-cloud/host';
+import type { CanvasView } from '@lace-cloud/proto';
 import * as vscode from 'vscode';
 import { ChatController, type ChatSidebarDeps } from './controller';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,20 +12,29 @@ importers:
         specifier: ^1.12.6
         version: 1.14.3
       '@lace-cloud/canvas':
-        specifier: ^0.1.1
-        version: 0.1.1(@types/react@18.3.28)
+        specifier: 0.1.1-next.24828814947
+        version: 0.1.1-next.24828814947(@types/react@18.3.28)
+      '@lace-cloud/chat-core':
+        specifier: 0.1.1-next.24828814947
+        version: 0.1.1-next.24828814947
       '@lace-cloud/chat-sidebar':
         specifier: workspace:*
         version: link:packages/chat-sidebar
       '@lace-cloud/chat-webview':
-        specifier: ^0.1.1
-        version: 0.1.1
+        specifier: 0.1.1-next.24828814947
+        version: 0.1.1-next.24828814947
       '@lace-cloud/design-tokens':
-        specifier: ^0.1.1
-        version: 0.1.1
+        specifier: 0.1.1-next.24828814947
+        version: 0.1.1-next.24828814947
       '@lace-cloud/host':
-        specifier: ^0.1.1
-        version: 0.1.1
+        specifier: 0.1.1-next.24828814947
+        version: 0.1.1-next.24828814947
+      '@lace-cloud/proto':
+        specifier: 0.1.1-next.24828814947
+        version: 0.1.1-next.24828814947
+      '@lace-cloud/ui':
+        specifier: 0.1.1-next.24828814947
+        version: 0.1.1-next.24828814947
       '@xyflow/react':
         specifier: ^12.10.1
         version: 12.10.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -97,20 +106,20 @@ importers:
   packages/chat-sidebar:
     dependencies:
       '@lace-cloud/chat-core':
-        specifier: ^0.1.1
-        version: 0.1.1
+        specifier: 0.1.1-next.24828814947
+        version: 0.1.1-next.24828814947
       '@lace-cloud/chat-webview':
-        specifier: ^0.1.1
-        version: 0.1.1
+        specifier: 0.1.1-next.24828814947
+        version: 0.1.1-next.24828814947
       '@lace-cloud/design-tokens':
-        specifier: ^0.1.1
-        version: 0.1.1
+        specifier: 0.1.1-next.24828814947
+        version: 0.1.1-next.24828814947
       '@lace-cloud/host':
-        specifier: ^0.1.1
-        version: 0.1.1
+        specifier: 0.1.1-next.24828814947
+        version: 0.1.1-next.24828814947
       '@lace-cloud/proto':
-        specifier: ^0.1.1
-        version: 0.1.1
+        specifier: 0.1.1-next.24828814947
+        version: 0.1.1-next.24828814947
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -617,26 +626,26 @@ packages:
     peerDependencies:
       tslib: '2'
 
-  '@lace-cloud/canvas@0.1.1':
-    resolution: {integrity: sha512-xg5bznuM9IGkboighEomXtArcDGfFmOMBVA/ifgCLn6jKEiwO5R/K51qdDRo5nq2y/Xxhqb2K+DUaYJcczBbYw==, tarball: https://npm.pkg.github.com/download/@lace-cloud/canvas/0.1.1/10998f34db350c08905be65ed9eff945f773ccee}
+  '@lace-cloud/canvas@0.1.1-next.24828814947':
+    resolution: {integrity: sha512-+hSEcPi2ABh0EYta3xr6nyvNA+yDYYDaI+eRAvI0Cul9YIP41ln5uXngabFp5b8Zwvu4rxcvf1vJOgY0tassvQ==, tarball: https://npm.pkg.github.com/download/@lace-cloud/canvas/0.1.1-next.24828814947/55a9e9a03cff48f32136a317aa9c51dd83075798}
 
-  '@lace-cloud/chat-core@0.1.1':
-    resolution: {integrity: sha512-P8ALhrpGjjKJ1Z/7znUGiWw/lyKEqwEaxDWgFHc3neyNqB/DSoccg/IXMyAPff11VSOqjoX9LIsgklUAfmft8Q==, tarball: https://npm.pkg.github.com/download/@lace-cloud/chat-core/0.1.1/1a2d2519049685a06db5adb597b615b09f0fd0d0}
+  '@lace-cloud/chat-core@0.1.1-next.24828814947':
+    resolution: {integrity: sha512-1sUGzTb+pHAqzb05za/pQmFF3muK13uKfLtSp8PKY2ugzU5JLoJuRKLjh9RbiYQGwn7XPZC9BaayXO3ik5q00Q==, tarball: https://npm.pkg.github.com/download/@lace-cloud/chat-core/0.1.1-next.24828814947/69f1ef5b2cfcd6778d070039033c7be82d70f5ee}
 
-  '@lace-cloud/chat-webview@0.1.1':
-    resolution: {integrity: sha512-e2yQjlFH+MTZ6eBMbDBaJzG9H8Utf1CsubF7X5rEKDKyhBea59JOuXnVg55nC7MW24ZEB8IhqSN0kLl41zYmDw==, tarball: https://npm.pkg.github.com/download/@lace-cloud/chat-webview/0.1.1/8bf913b2cc14b73bb9326498f8cd2d88b00f61ce}
+  '@lace-cloud/chat-webview@0.1.1-next.24828814947':
+    resolution: {integrity: sha512-06oqdo/yp1OUxCChCjWDc2zfwzKWakhBadEbxEFhbkK1qFWEviaKwxn2SpQU8Af3bAx6RQ1aGrUM+WBOyiI3Dw==, tarball: https://npm.pkg.github.com/download/@lace-cloud/chat-webview/0.1.1-next.24828814947/cf5b9508dd61cb650d1f3948e74b0f3e4029f53f}
 
-  '@lace-cloud/design-tokens@0.1.1':
-    resolution: {integrity: sha512-WFwYdhN7ihzo0Djibt0T6yog4KZviPt0OvKVQWDLrcpUn9fdBNYa/xydv/GHHzTysCxkLiWSR1yBtlSkOO1wTA==, tarball: https://npm.pkg.github.com/download/@lace-cloud/design-tokens/0.1.1/8d51259d72b32691ff65a9ab05f74b76a8e8000f}
+  '@lace-cloud/design-tokens@0.1.1-next.24828814947':
+    resolution: {integrity: sha512-zz36Ro4pVtj3bw1TtPCT2PoGo4JZZovEs2dK4iKuY/vIvW4py2CGrNLsCJSA9pYtvsqidqwyAXwgCjf4TClZ3A==, tarball: https://npm.pkg.github.com/download/@lace-cloud/design-tokens/0.1.1-next.24828814947/909ccce977bfeb90624da1f47842af99e41f76bc}
 
-  '@lace-cloud/host@0.1.1':
-    resolution: {integrity: sha512-mJFh2Yf322ifjTmpmlnjlX1GnpvoD5YLOAnoKDlTKBoDBZzQkDcJXxhtQ88uVUBbcoxpcC2PiE2px5B+Uot+UA==, tarball: https://npm.pkg.github.com/download/@lace-cloud/host/0.1.1/68d72c87f724689d39b431506cf43bff3b2cb0a1}
+  '@lace-cloud/host@0.1.1-next.24828814947':
+    resolution: {integrity: sha512-R3QAZ0rJ/v4gAEvFARdlu23jn2RhnOr+lmw5Wnhw5Xn1ReWOmHKJRA0VhqbnX+bpN9RqVxe/gFuaSpnkYKlaOw==, tarball: https://npm.pkg.github.com/download/@lace-cloud/host/0.1.1-next.24828814947/21edbd3139d28a403d43a471f21d072297a0cb64}
 
-  '@lace-cloud/proto@0.1.1':
-    resolution: {integrity: sha512-vU8PxcYxgFv5vgMarWjmjW71hc/AXJyD6gSiagSz+yRkquQ11zXxfBM3U4VMFH1jebtrEgryDsVtvbDDm10FZg==, tarball: https://npm.pkg.github.com/download/@lace-cloud/proto/0.1.1/5c01495162260e126a0381148ad0ffee89863662}
+  '@lace-cloud/proto@0.1.1-next.24828814947':
+    resolution: {integrity: sha512-MSjcQwGk5vf6xfV1dzeeqbr7mEvcMNwAUMkuPmhuAX1dybcoKondIPNLN8LiGk85dZfp5HWsP/KCSphH0yN1VA==, tarball: https://npm.pkg.github.com/download/@lace-cloud/proto/0.1.1-next.24828814947/fa667d7a507d4e278b9ab10b7f99cf812d394402}
 
-  '@lace-cloud/ui@0.1.1':
-    resolution: {integrity: sha512-tTkH+XfVwSd7Zqd+yXCEwJueMv8TISiKP1bjl/tpc6/9lTmvWkk2mpl/pL1C+3UJbiPuykONmhggmlX2+iRYFA==, tarball: https://npm.pkg.github.com/download/@lace-cloud/ui/0.1.1/bbe77244ab260e876c258f76aea4830d40b51655}
+  '@lace-cloud/ui@0.1.1-next.24828814947':
+    resolution: {integrity: sha512-3FFJoUO+DasUB//CrLQUik0xOf2dnzA0VTruJT71YBr5MbgH9zdWv+Qggjpq1Vxe11TOelKU1/s4akThBHUnCQ==, tarball: https://npm.pkg.github.com/download/@lace-cloud/ui/0.1.1-next.24828814947/a5c29096710040ed1049657bef326ea34c5b1a58}
 
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
@@ -3622,11 +3631,11 @@ snapshots:
       '@jsonjoy.com/codegen': 17.67.0(tslib@2.8.1)
       tslib: 2.8.1
 
-  '@lace-cloud/canvas@0.1.1(@types/react@18.3.28)':
+  '@lace-cloud/canvas@0.1.1-next.24828814947(@types/react@18.3.28)':
     dependencies:
       '@bufbuild/protobuf': 2.11.0
-      '@lace-cloud/proto': 0.1.1
-      '@lace-cloud/ui': 0.1.1
+      '@lace-cloud/proto': 0.1.1-next.24828814947
+      '@lace-cloud/ui': 0.1.1-next.24828814947
       '@xyflow/react': 12.10.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -3634,33 +3643,33 @@ snapshots:
       - '@types/react'
       - immer
 
-  '@lace-cloud/chat-core@0.1.1':
+  '@lace-cloud/chat-core@0.1.1-next.24828814947':
     dependencies:
-      '@lace-cloud/host': 0.1.1
-      '@lace-cloud/proto': 0.1.1
+      '@lace-cloud/host': 0.1.1-next.24828814947
+      '@lace-cloud/proto': 0.1.1-next.24828814947
 
-  '@lace-cloud/chat-webview@0.1.1':
+  '@lace-cloud/chat-webview@0.1.1-next.24828814947':
     dependencies:
-      '@lace-cloud/chat-core': 0.1.1
-      '@lace-cloud/design-tokens': 0.1.1
+      '@lace-cloud/chat-core': 0.1.1-next.24828814947
+      '@lace-cloud/design-tokens': 0.1.1-next.24828814947
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@lace-cloud/design-tokens@0.1.1': {}
+  '@lace-cloud/design-tokens@0.1.1-next.24828814947': {}
 
-  '@lace-cloud/host@0.1.1':
+  '@lace-cloud/host@0.1.1-next.24828814947':
     dependencies:
       '@bufbuild/protobuf': 2.11.0
       '@grpc/grpc-js': 1.14.3
-      '@lace-cloud/proto': 0.1.1
+      '@lace-cloud/proto': 0.1.1-next.24828814947
 
-  '@lace-cloud/proto@0.1.1':
+  '@lace-cloud/proto@0.1.1-next.24828814947':
     dependencies:
       '@bufbuild/protobuf': 2.11.0
 
-  '@lace-cloud/ui@0.1.1':
+  '@lace-cloud/ui@0.1.1-next.24828814947':
     dependencies:
-      '@lace-cloud/design-tokens': 0.1.1
+      '@lace-cloud/design-tokens': 0.1.1-next.24828814947
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 

--- a/src/vscode/canvas-panel.ts
+++ b/src/vscode/canvas-panel.ts
@@ -1,7 +1,6 @@
 import * as path from 'node:path';
 import {
-  type CanvasView,
-  type Diagnostic,
+  type BundleState,
   type HostToWebview,
   type LaceTransport,
   requireClient,
@@ -17,21 +16,7 @@ const LACE_DIR = '.lace';
 
 let canvasPanel: vscode.WebviewPanel | undefined;
 let isGenerating = false;
-let latestCanvasView: CanvasView | undefined;
 let subscribeHandler: SubscribeHandler | null = null;
-
-function isCanvasView(value: unknown): value is CanvasView {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'nodes' in value &&
-    Array.isArray((value as CanvasView).nodes)
-  );
-}
-
-export function getLatestCanvasView(): CanvasView | undefined {
-  return latestCanvasView;
-}
 
 export function getLaceDir(): string | undefined {
   const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
@@ -41,11 +26,6 @@ export function getLaceDir(): string | undefined {
 
 function postToWebview(panel: vscode.WebviewPanel, msg: HostToWebview) {
   panel.webview.postMessage(msg);
-}
-
-export function publishCanvasViewToActivePanel(state: CanvasView): void {
-  if (!canvasPanel) return;
-  postToWebview(canvasPanel, { command: 'loadState', state });
 }
 
 function requireTransport(server: ServerManager, action: string): LaceTransport {
@@ -63,19 +43,28 @@ export async function addModuleToActiveCanvas(
     vscode.window.showWarningMessage('No canvas open.');
     return;
   }
-  const panel = canvasPanel;
   await vscode.window.withProgress(
     { location: vscode.ProgressLocation.Notification, title: `Adding ${name}...` },
     async () => {
       try {
         const transport = requireTransport(server, 'place module');
-        const view = await transport.placeModule({ name, system, version, organization });
-        latestCanvasView = view;
-        postToWebview(panel, {
-          command: 'loadState',
-          state: view,
-          viewportIntent: { kind: 'fit-all', padding: 0.2, duration: 300 },
-        });
+        const result = await transport.applyAction([
+          {
+            place_module: {
+              name,
+              system,
+              version,
+              organization: organization ?? '',
+              position: undefined,
+            },
+          },
+        ]);
+        if (!result.success) {
+          const reason = result.errors.map((e) => e.message).join('; ') || 'unknown';
+          vscode.window.showErrorMessage(`Add module rejected: ${reason}`);
+        }
+        // Post-mutation BundleState arrives via Subscribe and is
+        // forwarded to the webview automatically; no optimistic push.
       } catch (err: unknown) {
         handleRpcError(err, 'placeModule', 'add module to canvas');
       }
@@ -97,7 +86,7 @@ export async function triggerGenerateOnActiveCanvas(server: ServerManager) {
       output_dir: laceDir,
       options: { dry_run: false, format: true, validate: true, overwrite: true },
     });
-    const errors = (result?.diagnostics ?? []).filter((d: Diagnostic) => d.severity === 'error');
+    const errors = (result?.diagnostics ?? []).filter((d) => d.severity === 'error');
     if (errors.length > 0) {
       postToWebview(panel, {
         command: 'generateError',
@@ -131,8 +120,6 @@ window.addEventListener('DOMContentLoaded', () => {
 });
 `.trim();
 
-// Body bg uses the user's editor background so the brief flash before
-// the React canvas mounts theme-matches VS Code (light/dark/HC).
 const CANVAS_BODY_STYLE = `body { margin: 0; padding: 0; height: 100vh; background: var(--vscode-editor-background); display: flex; flex-direction: column; }`;
 
 export async function openCanvas(context: vscode.ExtensionContext, server: ServerManager) {
@@ -199,25 +186,27 @@ export async function openCanvas(context: vscode.ExtensionContext, server: Serve
   });
   const safetyTimeout = setTimeout(resolveReady!, 10_000);
 
+  function forwardState(state: BundleState) {
+    postToWebview(panel, { command: 'loadState', state });
+  }
+
   panel.webview.onDidReceiveMessage(
     async (msg: WebviewToHost | { command: string; [key: string]: unknown }) => {
       switch (msg.command) {
         case 'webviewReady': {
           try {
             const transport = requireTransport(server, 'session/open');
-            const { view } = await transport.sessionOpen({
+            const { state } = await transport.sessionOpen({
               file_path: laceDir,
               workspace_name: folderName,
             });
-            latestCanvasView = view;
-            postToWebview(panel, { command: 'loadState', state: view });
+            forwardState(state);
             const sessionId = transport.sessionId;
             if (sessionId) {
               subscribeHandler = new SubscribeHandler();
               subscribeHandler.start(transport.subscribeStream(sessionId), {
-                onStateUpdated: (v) => {
-                  latestCanvasView = v;
-                  postToWebview(panel, { command: 'loadState', state: v });
+                onStateUpdated: (nextState) => {
+                  forwardState(nextState);
                 },
                 onGenerateProgress: (stage) => {
                   postToWebview(panel, {
@@ -257,7 +246,6 @@ export async function openCanvas(context: vscode.ExtensionContext, server: Serve
           try {
             const transport = requireTransport(server, method);
             const result = await transport.dispatch(method, params);
-            if (isCanvasView(result)) latestCanvasView = result;
             postToWebview(panel, { command: 'engineResult', requestId, result });
           } catch (err: unknown) {
             postToWebview(panel, {


### PR DESCRIPTION
## Summary
- Pins `@lace-cloud/*` deps to `0.1.1-next.24828814947` — the prerelease published after monorepo PR #123 (projection Uses-only refactor).
- Host-side bridge (canvas-panel.ts) forwards raw `BundleState` (Bundle + Layouts + undo/redo flags) to the webview; the webview's `PostMessageEngine` projects locally. No CanvasView crosses the wire anymore.
- ChatController migrated to the typed `SubscribeHandler.start(stream, callbacks)` pattern. Projects BundleState locally via `projectCanvasView`. Exposes `awaitNextView()` so tools can set up a state-update waiter before `applyAction`.
- All 13 chat tool per-method transport calls (`placeModule`, `connect`, `disconnect`, `updateInput`, `renameInstance`, `deleteInstance`, `setVariables`, `setLocals`, `setEnvironments`, `createGroup`, `deleteGroup`, `autoConnect`, `undo`) migrated to single `applyAction([{ <variant>: ... }])`. `BundleApplyResult` surfaces validation errors; tools that need post-state use `applyActionAndAwaitView` helper.

## Verification
- [x] `pnpm run lint` clean
- [x] `pnpm run test:unit` 68/68 pass
- [x] `npx tsc --noEmit` clean
- [x] `pnpm run build` (rspack all three bundles) green

## Plan reference
Arc P10 Plan PR E1 — see `~/.claude/plans/drifting-bubbling-sparrow.md` §E1.

## Depends on
- Monorepo PR #121 (atomic cutover) merged to develop ✓
- Monorepo PR #123 (projection Uses-only refactor) merged to develop ✓
- Prerelease `0.1.1-next.24828814947` published ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)