### PR TITLE
Arc P5 E2: VS Code Deploy panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,16 @@
           "id": "laceChat",
           "name": "Chat",
           "type": "webview"
+        },
+        {
+          "id": "laceDeploy",
+          "name": "Deploy",
+          "type": "webview"
+        },
+        {
+          "id": "laceDeployRuns",
+          "name": "Recent runs",
+          "type": "tree"
         }
       ]
     },
@@ -102,6 +112,15 @@
       {
         "command": "lace.clearChatHistory",
         "title": "Lace: Clear Chat History"
+      },
+      {
+        "command": "lace.deploy.refreshRuns",
+        "title": "Refresh runs",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "lace.deploy.showRun",
+        "title": "Lace: Show run"
       }
     ],
     "configuration": {
@@ -133,6 +152,11 @@
           ],
           "default": "on",
           "description": "Enable rule-based suggestions when state changes between chat turns."
+        },
+        "lace.portalUrl": {
+          "type": "string",
+          "default": "",
+          "description": "Base URL of your Lace portal (e.g., https://portal.lace.cloud). Used for 'Open in portal' deep-links in the Deploy panel. Leave empty to disable."
         }
       }
     },
@@ -141,6 +165,11 @@
         {
           "command": "lace.refreshRegistry",
           "when": "view == laceRegistry",
+          "group": "navigation"
+        },
+        {
+          "command": "lace.deploy.refreshRuns",
+          "when": "view == laceDeployRuns",
           "group": "navigation"
         }
       ]

--- a/package.json
+++ b/package.json
@@ -189,11 +189,14 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.12.6",
-    "@lace-cloud/canvas": "^0.1.1",
-    "@lace-cloud/chat-webview": "^0.1.1",
-    "@lace-cloud/design-tokens": "^0.1.1",
-    "@lace-cloud/host": "^0.1.1",
+    "@lace-cloud/canvas": "0.1.1-next.24828814947",
+    "@lace-cloud/chat-core": "0.1.1-next.24828814947",
     "@lace-cloud/chat-sidebar": "workspace:*",
+    "@lace-cloud/chat-webview": "0.1.1-next.24828814947",
+    "@lace-cloud/design-tokens": "0.1.1-next.24828814947",
+    "@lace-cloud/host": "0.1.1-next.24828814947",
+    "@lace-cloud/proto": "0.1.1-next.24828814947",
+    "@lace-cloud/ui": "0.1.1-next.24828814947",
     "@xyflow/react": "^12.10.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/packages/chat-sidebar/package.json
+++ b/packages/chat-sidebar/package.json
@@ -9,11 +9,11 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@lace-cloud/chat-core": "^0.1.1",
-    "@lace-cloud/chat-webview": "^0.1.1",
-    "@lace-cloud/design-tokens": "^0.1.1",
-    "@lace-cloud/host": "^0.1.1",
-    "@lace-cloud/proto": "^0.1.1",
+    "@lace-cloud/chat-core": "0.1.1-next.24828814947",
+    "@lace-cloud/chat-webview": "0.1.1-next.24828814947",
+    "@lace-cloud/design-tokens": "0.1.1-next.24828814947",
+    "@lace-cloud/host": "0.1.1-next.24828814947",
+    "@lace-cloud/proto": "0.1.1-next.24828814947",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/packages/chat-sidebar/src/__tests__/chat-tools.test.ts
+++ b/packages/chat-sidebar/src/__tests__/chat-tools.test.ts
@@ -1,34 +1,31 @@
 import { createToolRegistry, type ToolRegistry } from '@lace-cloud/chat-core';
 import type { LaceTransport, RegistryModule, RenderError } from '@lace-cloud/host';
+import type { CanvasView } from '@lace-cloud/proto';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { type GenerateToolDeps, registerGenerateTools } from '../host/tools/generate-tools';
 import { registerGraphReadTools } from '../host/tools/graph-read-tools';
 import { type GraphWriteDeps, registerGraphWriteTools } from '../host/tools/graph-write-tools';
 import { makeCanvasView, makeEdge, makeNode } from './helpers';
 
-// ── Mock RPC client ──
+// ── Mock RPC client (post-P10: single applyAction surface + read queries) ──
 
 function makeMockClient(overrides: Record<string, unknown> = {}) {
   return {
-    placeModule: vi
-      .fn()
-      .mockResolvedValue(makeCanvasView([makeNode('vpc', 'module', 'aws/vpc@v1.0.0')])),
+    applyAction: vi.fn().mockResolvedValue({ success: true, errors: [] }),
     inspectModule: vi.fn().mockResolvedValue({
       name: 'aws/vpc',
       system: 'aws',
       version: 'v1.0.0',
       module_interface: { inputs: [], outputs: [] },
     }),
-    updateInput: vi.fn().mockResolvedValue(makeCanvasView([makeNode('vpc')])),
-    autoConnect: vi
-      .fn()
-      .mockResolvedValue(
-        makeCanvasView(
-          [makeNode('vpc'), makeNode('subnet')],
-          [makeEdge('vpc', 'subnet', 'vpc_id', 'vpc_id')],
-        ),
-      ),
-    syncLayout: vi.fn().mockResolvedValue({}),
+    queryNodeConfig: vi.fn().mockResolvedValue({
+      instance_id: 'vpc',
+      inputs: [],
+      outputs: [],
+      sibling_ids: [],
+      depends_on: [],
+      available_variables: [],
+    }),
     queryValidate: vi.fn().mockResolvedValue({ errors: [] as RenderError[] }),
     querySettings: vi.fn().mockResolvedValue({
       terraform: { required_version: '', required_providers: [] },
@@ -36,14 +33,21 @@ function makeMockClient(overrides: Record<string, unknown> = {}) {
       locals: [],
       environments: {},
     }),
-    setLocals: vi.fn().mockResolvedValue(makeCanvasView([makeNode('vpc')])),
-    setEnvironments: vi.fn().mockResolvedValue({}),
     sessionGenerate: vi.fn().mockResolvedValue({
       files_written: ['main.tf'],
       diagnostics: [],
     }),
     ...overrides,
   };
+}
+
+/**
+ * Next-view stub for tests: tools that call `applyActionAndAwaitView`
+ * receive this view after the applyAction mock resolves. Tests that
+ * need to inspect the post-mutation view override this per-assertion.
+ */
+function makeAwaitNextView(view: CanvasView | null) {
+  return () => Promise.resolve(view);
 }
 
 // ── Registry module fixtures ──
@@ -80,13 +84,16 @@ const testModules: RegistryModule[] = [
 let mockClient: ReturnType<typeof makeMockClient>;
 let registry: ToolRegistry;
 
-function makeWriteDeps(): GraphWriteDeps {
+function makeWriteDeps(
+  nextView: CanvasView | null = makeCanvasView([makeNode('vpc', 'module', 'aws/vpc@v1.0.0')]),
+): GraphWriteDeps {
   mockClient = makeMockClient();
   return {
     getRpcClient: () => mockClient as unknown as LaceTransport,
     getRegistryModules: () => testModules,
     getUserOrgs: () => [],
     getCanvasView: () => null,
+    awaitNextView: makeAwaitNextView(nextView),
   };
 }
 
@@ -102,20 +109,22 @@ describe('write tools', () => {
   });
 
   describe('lace_add_module', () => {
-    test('adds module by exact name via placeModule RPC', async () => {
+    test('adds module by exact name via applyAction RPC', async () => {
       const handler = registry.getHandler('lace_add_module')!;
       const result = await handler({ name: 'aws/vpc' });
 
       expect(result.isError).toBeFalsy();
       expect(result.content).toContain('aws/vpc');
       expect(result.content).toContain('instance **"vpc"**');
-      expect(mockClient.placeModule).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: 'aws/vpc',
-          system: 'aws',
-          version: 'v1.0.0',
-        }),
-      );
+      expect(mockClient.applyAction).toHaveBeenCalledWith([
+        {
+          place_module: expect.objectContaining({
+            name: 'aws/vpc',
+            system: 'aws',
+            version: 'v1.0.0',
+          }),
+        },
+      ]);
     });
 
     test('resolves single fuzzy match', async () => {
@@ -124,13 +133,15 @@ describe('write tools', () => {
 
       expect(result.isError).toBeFalsy();
       expect(result.content).toContain('azure/resource-group');
-      expect(mockClient.placeModule).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: 'azure/resource-group',
-          system: 'azure',
-          version: 'v2.0.0',
-        }),
-      );
+      expect(mockClient.applyAction).toHaveBeenCalledWith([
+        {
+          place_module: expect.objectContaining({
+            name: 'azure/resource-group',
+            system: 'azure',
+            version: 'v2.0.0',
+          }),
+        },
+      ]);
     });
 
     test('disambiguates multiple fuzzy matches', async () => {
@@ -141,15 +152,14 @@ describe('write tools', () => {
       expect(result.content).toContain('Multiple modules match');
       expect(result.content).toContain('aws/vpc');
       expect(result.content).toContain('aws/subnet');
-      expect(mockClient.placeModule).not.toHaveBeenCalled();
+      expect(mockClient.applyAction).not.toHaveBeenCalled();
     });
 
     test('passes org provenance when module found in user org', async () => {
-      // Simulate: private module not in local cache, found via RPC in org
       mockClient = makeMockClient({
         listRegistryModules: vi
           .fn()
-          .mockResolvedValueOnce({ modules: [] }) // public: not found
+          .mockResolvedValueOnce({ modules: [] })
           .mockResolvedValueOnce({
             modules: [
               {
@@ -164,9 +174,12 @@ describe('write tools', () => {
 
       const deps: GraphWriteDeps = {
         getRpcClient: () => mockClient as unknown as LaceTransport,
-        getRegistryModules: () => [], // empty local cache — forces RPC search
+        getRegistryModules: () => [],
         getUserOrgs: () => [{ slug: 'acme-corp', name: 'Acme Corp', role: 'member' }],
         getCanvasView: () => null,
+        awaitNextView: makeAwaitNextView(
+          makeCanvasView([makeNode('custom-networking', 'module', 'aws/custom-networking@v1.0.0')]),
+        ),
       };
       registry = createToolRegistry();
       registerGraphWriteTools(registry, deps);
@@ -179,13 +192,16 @@ describe('write tools', () => {
       const result = await handler({ name: 'aws/custom-networking' });
 
       expect(result.isError).toBeFalsy();
-      expect(mockClient.placeModule).toHaveBeenCalledWith(
-        expect.objectContaining({ organization: 'acme-corp' }),
-      );
+      expect(mockClient.applyAction).toHaveBeenCalledWith([
+        { place_module: expect.objectContaining({ organization: 'acme-corp' }) },
+      ]);
     });
 
-    test('surfaces engine error when placeModule fails', async () => {
-      mockClient.placeModule.mockRejectedValue(new Error('module not found in registry'));
+    test('surfaces engine error when applyAction rejects', async () => {
+      mockClient.applyAction.mockResolvedValue({
+        success: false,
+        errors: [{ instance_id: '', input_name: '', message: 'module not found in registry' }],
+      });
       const handler = registry.getHandler('lace_add_module')!;
       const result = await handler({ name: 'aws/vpc' });
 
@@ -205,14 +221,15 @@ describe('write tools', () => {
 
       expect(result.isError).toBeFalsy();
       expect(result.content).toContain('literal true');
-      expect(mockClient.updateInput).toHaveBeenCalledWith({
-        instance_id: 'vpc',
-        input_name: 'enable_dns',
-        mode: 'literal',
-        value: true,
-        variable: undefined,
-        expression: undefined,
-      });
+      expect(mockClient.applyAction).toHaveBeenCalledWith([
+        {
+          update_input: expect.objectContaining({
+            instance_id: 'vpc',
+            input_name: 'enable_dns',
+            value: true,
+          }),
+        },
+      ]);
     });
 
     test('sets variable reference', async () => {
@@ -225,14 +242,15 @@ describe('write tools', () => {
 
       expect(result.isError).toBeFalsy();
       expect(result.content).toContain('variable "vpc_cidr"');
-      expect(mockClient.updateInput).toHaveBeenCalledWith({
-        instance_id: 'vpc',
-        input_name: 'cidr_block',
-        mode: 'variable',
-        value: undefined,
-        variable: 'vpc_cidr',
-        expression: undefined,
-      });
+      expect(mockClient.applyAction).toHaveBeenCalledWith([
+        {
+          update_input: expect.objectContaining({
+            instance_id: 'vpc',
+            input_name: 'cidr_block',
+            variable: 'vpc_cidr',
+          }),
+        },
+      ]);
     });
 
     test('returns error when no binding type provided', async () => {
@@ -272,6 +290,12 @@ describe('generate tools', () => {
       getRpcClient: () => mockClient as unknown as LaceTransport,
       getLaceDir: () => '/tmp/test-workspace/.lace',
       getCanvasView: () => null,
+      awaitNextView: makeAwaitNextView(
+        makeCanvasView(
+          [makeNode('vpc'), makeNode('subnet')],
+          [makeEdge('vpc', 'subnet', 'vpc_id', 'vpc_id')],
+        ),
+      ),
     };
     registerGenerateTools(registry, deps);
   });
@@ -287,16 +311,21 @@ describe('generate tools', () => {
       expect(result.isError).toBeFalsy();
       expect(result.content).toContain('Auto-connected 1 wire(s)');
       expect(result.content).toContain('vpc.vpc_id');
-      expect(mockClient.autoConnect).toHaveBeenCalledWith({
-        source: 'vpc',
-        target: 'subnet',
-      });
+      expect(mockClient.applyAction).toHaveBeenCalledWith([
+        { auto_connect: { source: 'vpc', target: 'subnet' } },
+      ]);
     });
 
     test('reports no match when no edges returned', async () => {
-      mockClient.autoConnect.mockResolvedValue(
-        makeCanvasView([makeNode('vpc'), makeNode('subnet')]),
-      );
+      mockClient = makeMockClient();
+      registry = createToolRegistry();
+      const deps: GenerateToolDeps = {
+        getRpcClient: () => mockClient as unknown as LaceTransport,
+        getLaceDir: () => '/tmp/test-workspace/.lace',
+        getCanvasView: () => null,
+        awaitNextView: makeAwaitNextView(makeCanvasView([makeNode('vpc'), makeNode('subnet')])),
+      };
+      registerGenerateTools(registry, deps);
       const handler = registry.getHandler('lace_auto_connect')!;
       const result = await handler({
         source_instance: 'vpc',
@@ -343,6 +372,7 @@ describe('generate tools', () => {
         getRpcClient: () => mockClient as unknown as LaceTransport,
         getLaceDir: () => undefined,
         getCanvasView: () => null,
+        awaitNextView: makeAwaitNextView(null),
       };
       registry = createToolRegistry();
       registerGenerateTools(registry, deps);
@@ -372,9 +402,19 @@ describe('settings tools', () => {
       expect(result.content).toContain('region');
       expect(result.content).toContain('us-east-1');
       expect(mockClient.querySettings).toHaveBeenCalled();
-      expect(mockClient.setLocals).toHaveBeenCalledWith({
-        locals: [{ name: 'region', mode: 'literal', value: 'us-east-1', expression: undefined }],
-      });
+      expect(mockClient.applyAction).toHaveBeenCalledWith([
+        {
+          set_locals: {
+            locals: [
+              expect.objectContaining({
+                name: 'region',
+                mode: 'literal',
+                value: 'us-east-1',
+              }),
+            ],
+          },
+        },
+      ]);
     });
 
     test('sets expression local', async () => {
@@ -383,11 +423,19 @@ describe('settings tools', () => {
 
       expect(result.isError).toBeFalsy();
       expect(result.content).toContain('expression');
-      expect(mockClient.setLocals).toHaveBeenCalledWith({
-        locals: [
-          { name: 'prefix', mode: 'expression', value: undefined, expression: 'var.project' },
-        ],
-      });
+      expect(mockClient.applyAction).toHaveBeenCalledWith([
+        {
+          set_locals: {
+            locals: [
+              expect.objectContaining({
+                name: 'prefix',
+                mode: 'expression',
+                expression: 'var.project',
+              }),
+            ],
+          },
+        },
+      ]);
     });
 
     test('returns error when neither value nor expression provided', async () => {
@@ -411,9 +459,13 @@ describe('settings tools', () => {
       expect(result.content).toContain('staging');
       expect(result.content).toContain('region');
       expect(mockClient.querySettings).toHaveBeenCalled();
-      expect(mockClient.setEnvironments).toHaveBeenCalledWith({
-        environments: { staging: { region: 'us-west-2', instance_type: 't3.small' } },
-      });
+      expect(mockClient.applyAction).toHaveBeenCalledWith([
+        {
+          set_environments: expect.objectContaining({
+            environments: { staging: { region: 'us-west-2', instance_type: 't3.small' } },
+          }),
+        },
+      ]);
     });
 
     test('returns error when environment name missing', async () => {

--- a/packages/chat-sidebar/src/host/controller.ts
+++ b/packages/chat-sidebar/src/host/controller.ts
@@ -3,9 +3,11 @@
 //
 // Responsibilities here — and only here:
 //   1. Build the VS Code adapter + webview transport.
-//   2. Maintain the latest CanvasView by consuming the engine's
-//      Subscribe stream (so tools can read it synchronously via
-//      `deps.getCanvasView`).
+//   2. Consume the engine's Subscribe stream (BundleStateEvent), project
+//      BundleState locally into a CanvasView, and expose both:
+//        - `getCanvasView()` — synchronous snapshot of the latest view
+//        - `awaitNextView()` — promise resolving on the next state update
+//      so tools can read synchronously or wait for post-mutation state.
 //   3. Own the engine session lifecycle for the chat (open session,
 //      refresh context summary, mount proactivity).
 //   4. Register the VS Code-side tool set on a per-instance
@@ -13,8 +15,7 @@
 //   5. Delegate the agentic loop to `AgentController` from chat-core.
 //
 // No agentic-loop logic, no message codecs, no rule evaluation. Those
-// live in chat-core. When we port to JetBrains, this file is the
-// shape the JetBrains controller mirrors — the rest is unchanged.
+// live in chat-core.
 
 import {
   AgentController,
@@ -24,8 +25,10 @@ import {
   ProactivityWatcher,
   type ToolRegistry,
 } from '@lace-cloud/chat-core';
-import type { CanvasView, EngineEvent, LaceTransport, RegistryModule } from '@lace-cloud/host';
-import { convertCanvasView } from '@lace-cloud/host';
+import type { BundleState, LaceTransport, RegistryModule } from '@lace-cloud/host';
+import { SubscribeHandler } from '@lace-cloud/host';
+import type { CanvasView } from '@lace-cloud/proto';
+import { parseModuleKey, projectCanvasView } from '@lace-cloud/proto';
 import * as vscode from 'vscode';
 import { createVsCodeChatAdapter } from '../vscode-adapter';
 import { createVsCodeWebviewTransport } from '../vscode-webview-transport';
@@ -49,8 +52,9 @@ export class ChatController {
   private readonly agent: AgentController;
   private readonly outputChannel: vscode.OutputChannel;
   private latestView: CanvasView | null = null;
-  private subscribeHandler: ReturnType<LaceTransport['subscribeStream']> | null = null;
+  private subscribeHandler: SubscribeHandler | null = null;
   private proactivity: ProactivityWatcher | null = null;
+  private stateUpdateWaiters: Array<(view: CanvasView | null) => void> = [];
 
   constructor(
     context: vscode.ExtensionContext,
@@ -94,10 +98,13 @@ export class ChatController {
 
   dispose(): void {
     this.agent.dispose();
-    this.subscribeHandler?.cancel();
+    this.subscribeHandler?.stop();
     this.subscribeHandler = null;
     this.proactivity?.stop();
     this.proactivity = null;
+    // Reject any pending awaiters so callers don't hang on dispose.
+    for (const resolve of this.stateUpdateWaiters) resolve(null);
+    this.stateUpdateWaiters = [];
   }
 
   async clearHistory(): Promise<void> {
@@ -108,12 +115,26 @@ export class ChatController {
     return this.latestView;
   }
 
+  /**
+   * Returns a promise that resolves on the NEXT BundleState arrival on
+   * the Subscribe stream (with the newly-projected CanvasView, or null
+   * if the stream ended / errored before the next event). Tools that
+   * mutate state via applyAction call this BEFORE applyAction to set
+   * up the waiter, then await the promise AFTER applyAction returns.
+   */
+  awaitNextView(): Promise<CanvasView | null> {
+    return new Promise((resolve) => {
+      this.stateUpdateWaiters.push(resolve);
+    });
+  }
+
   // ── Private ──
 
   private registerTools(): void {
     const deps = {
       ...this.externalDeps,
       getCanvasView: () => this.latestView,
+      awaitNextView: () => this.awaitNextView(),
     };
     registerRegistryTools(this.registry, deps);
     registerGraphReadTools(this.registry, deps);
@@ -126,10 +147,6 @@ export class ChatController {
     if (this.subscribeHandler) return;
     const transport = this.externalDeps.getRpcClient();
     if (!transport?.sessionId) {
-      // Attempt a lazy session-open so the Subscribe stream is
-      // available from the first turn. If no workspace is open or
-      // the engine isn't running, the runTurn path surfaces the
-      // error to the webview.
       void this.ensureSession().then(() => this.openSubscribe());
       return;
     }
@@ -145,10 +162,11 @@ export class ChatController {
     const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
     if (!laceDir || !workspaceFolder) return null;
 
-    const { session_id } = await transport.sessionOpen({
+    const { session_id, state } = await transport.sessionOpen({
       file_path: laceDir,
       workspace_name: workspaceFolder.name,
     });
+    this.adoptState(state);
     return session_id;
   }
 
@@ -159,15 +177,20 @@ export class ChatController {
       return;
     }
 
-    this.subscribeHandler = transport.subscribeStream(transport.sessionId);
-    this.subscribeHandler.on('data', (event: EngineEvent) => this.handleEngineEvent(event));
-    this.subscribeHandler.on('end', () => {
-      this.subscribeHandler = null;
-    });
-    this.subscribeHandler.on('error', () => {
-      this.subscribeHandler = null;
-      // Avoid tight retry loops — if the engine dies mid-session, the
-      // next user turn will attempt to re-establish the session.
+    this.subscribeHandler = new SubscribeHandler();
+    this.subscribeHandler.start(transport.subscribeStream(transport.sessionId), {
+      onStateUpdated: (state) => this.adoptState(state),
+      onGenerateProgress: () => {},
+      onGenerateSuccess: () => {},
+      onGenerateError: () => {},
+      onEnd: () => {
+        this.subscribeHandler = null;
+      },
+      onError: () => {
+        this.subscribeHandler = null;
+        // Avoid tight retry loops — if the engine dies mid-session, the
+        // next user turn will attempt to re-establish the session.
+      },
     });
 
     this.proactivity = new ProactivityWatcher({
@@ -183,11 +206,21 @@ export class ChatController {
     this.proactivity.start();
   }
 
-  private handleEngineEvent(event: EngineEvent): void {
-    if (event.state_updated?.view) {
-      this.latestView = convertCanvasView(event.state_updated.view);
-      this.postContextSummary();
-    }
+  private adoptState(state: BundleState): void {
+    if (!state.bundle) return;
+    const { id: moduleName } = parseModuleKey(state.bundle.entry);
+    const view = projectCanvasView(state.bundle, state.layouts ?? {}, {
+      moduleName,
+      canUndo: state.can_undo,
+      canRedo: state.can_redo,
+      isDirty: state.is_dirty,
+    });
+    this.latestView = view;
+    this.postContextSummary();
+
+    const waiters = this.stateUpdateWaiters;
+    this.stateUpdateWaiters = [];
+    for (const resolve of waiters) resolve(view);
   }
 
   private postContextSummary(): void {

--- a/packages/chat-sidebar/src/host/tools/generate-tools.ts
+++ b/packages/chat-sidebar/src/host/tools/generate-tools.ts
@@ -4,13 +4,15 @@
 // All operations go through RPC to the CLI.
 
 import type { ToolRegistry, ToolResult } from '@lace-cloud/chat-core';
-import type { CanvasView, LaceTransport } from '@lace-cloud/host';
-import { errorMessage, requireEngine } from './helpers';
+import type { LaceTransport } from '@lace-cloud/host';
+import type { CanvasView } from '@lace-cloud/proto';
+import { applyActionAndAwaitView, applyReason, errorMessage, requireEngine } from './helpers';
 
 export type GenerateToolDeps = {
   getRpcClient: () => LaceTransport | null;
   getLaceDir: () => string | undefined;
   getCanvasView: () => CanvasView | null;
+  awaitNextView: () => Promise<CanvasView | null>;
 };
 
 export function registerGenerateTools(registry: ToolRegistry, deps: GenerateToolDeps): void {
@@ -49,13 +51,17 @@ export function registerGenerateTools(registry: ToolRegistry, deps: GenerateTool
       if ('error' in engineResult) return engineResult.error;
 
       try {
-        const canvasView = await engineResult.client.autoConnect({
-          source: sourceInstance,
-          target: targetInstance,
-        });
+        const { result, view } = await applyActionAndAwaitView(
+          engineResult.client,
+          { auto_connect: { source: sourceInstance, target: targetInstance } },
+          deps.awaitNextView,
+        );
+        if (!result.success) {
+          return { content: `Failed to auto-connect: ${applyReason(result)}`, isError: true };
+        }
 
         // Count new edges involving these instances
-        const relevantEdges = canvasView.edges.filter(
+        const relevantEdges = (view?.edges ?? []).filter(
           (e) => e.source === sourceInstance && e.target === targetInstance,
         );
 

--- a/packages/chat-sidebar/src/host/tools/graph-read-tools.ts
+++ b/packages/chat-sidebar/src/host/tools/graph-read-tools.ts
@@ -4,7 +4,8 @@
 // All operations go through RPC to the CLI.
 
 import { formatCanvasState, type ToolRegistry, type ToolResult } from '@lace-cloud/chat-core';
-import type { CanvasView, LaceTransport } from '@lace-cloud/host';
+import type { LaceTransport } from '@lace-cloud/host';
+import type { CanvasView } from '@lace-cloud/proto';
 import { errorMessage, requireEngine } from './helpers';
 
 export type GraphReadDeps = {

--- a/packages/chat-sidebar/src/host/tools/graph-write-tools.ts
+++ b/packages/chat-sidebar/src/host/tools/graph-write-tools.ts
@@ -2,17 +2,26 @@
 //
 // Write tools: lace_add_module, lace_remove_module, lace_connect,
 // lace_disconnect, lace_set_input, lace_rename_instance, lace_set_variable, lace_undo.
-// All operations go through RPC to the CLI.
+// All mutations traverse the single ApplyAction RPC on the transport.
 
 import type { ToolRegistry, ToolResult } from '@lace-cloud/chat-core';
-import type { CanvasView, LaceTransport, RegistryModule } from '@lace-cloud/host';
-import { errorMessage, requireEngine } from './helpers';
+import type { LaceTransport, RegistryModule } from '@lace-cloud/host';
+import type { CanvasView } from '@lace-cloud/proto';
+import { modeToInputMode } from '@lace-cloud/proto';
+import {
+  applyAction,
+  applyActionAndAwaitView,
+  applyReason,
+  errorMessage,
+  requireEngine,
+} from './helpers';
 
 export type GraphWriteDeps = {
   getRpcClient: () => LaceTransport | null;
   getRegistryModules: () => RegistryModule[];
   getUserOrgs: () => Array<{ slug: string; name: string; role: string }>;
   getCanvasView: () => CanvasView | null;
+  awaitNextView: () => Promise<CanvasView | null>;
 };
 
 // ── Tool Registration ──
@@ -145,25 +154,35 @@ export function registerGraphWriteTools(registry: ToolRegistry, deps: GraphWrite
       if ('error' in engineResult) return engineResult.error;
 
       try {
-        // PlaceModule: single RPC — CLI fetches the bundle, places the module,
-        // and handles layout positioning server-side.
         const existingNodes = deps.getCanvasView()?.nodes ?? [];
         const existingIds = new Set(existingNodes.map((n) => n.id));
 
-        const canvasView = await engineResult.client.placeModule({
-          name: match.name,
-          system: match.system,
-          version: versionToAdd,
-          organization: matchOrg,
-        });
+        const { result, view } = await applyActionAndAwaitView(
+          engineResult.client,
+          {
+            place_module: {
+              name: match.name,
+              system: match.system,
+              version: versionToAdd,
+              organization: matchOrg ?? '',
+              position: undefined,
+            },
+          },
+          deps.awaitNextView,
+        );
 
-        const newNodes = canvasView.nodes.filter((n) => !existingIds.has(n.id));
+        if (!result.success) {
+          return {
+            content: `Failed to add module: ${applyReason(result)}`,
+            isError: true,
+          };
+        }
 
-        // Find the newly added instance ID — try module_key match first, then new node
+        const nodes = view?.nodes ?? [];
+        const newNodes = nodes.filter((n) => !existingIds.has(n.id));
         const instanceId =
-          canvasView.nodes.find((n) => n.module_key?.includes(match?.id))?.id ?? newNodes[0]?.id;
+          nodes.find((n) => n.module_key?.includes(match?.id ?? ''))?.id ?? newNodes[0]?.id;
 
-        // Build response with required inputs so model can set them immediately
         const lines: string[] = [];
 
         if (instanceId) {
@@ -261,7 +280,15 @@ export function registerGraphWriteTools(registry: ToolRegistry, deps: GraphWrite
       }
 
       try {
-        await engineResult.client.deleteInstance({ instance_id: instanceId });
+        const result = await applyAction(engineResult.client, {
+          delete_instance: { instance_id: instanceId },
+        });
+        if (!result.success) {
+          return {
+            content: `Failed to remove instance: ${applyReason(result)}`,
+            isError: true,
+          };
+        }
 
         const lines = [`Removed instance "${instanceId}" from the canvas.`];
         if (warnLines.length > 0) {
@@ -334,21 +361,29 @@ export function registerGraphWriteTools(registry: ToolRegistry, deps: GraphWrite
       if ('error' in engineResult) return engineResult.error;
 
       try {
-        await engineResult.client.connect({
-          source: sourceInstance,
-          target: targetInstance,
-          source_output: sourceOutput,
-          target_input: targetInput,
+        const result = await applyAction(engineResult.client, {
+          connect: {
+            source: sourceInstance,
+            target: targetInstance,
+            source_output: sourceOutput,
+            target_input: targetInput,
+          },
         });
+        if (!result.success) {
+          const reason = applyReason(result);
+          const notFound =
+            reason.toLowerCase().includes('not found') || reason.toLowerCase().includes('unknown');
+          return {
+            content: `Failed to connect: ${reason}${notFound ? '\nUse lace_inspect_node on each instance to see exact output/input names. Instance IDs come from the canvas snapshot.' : ''}`,
+            isError: true,
+          };
+        }
         return {
           content: `Connected ${sourceInstance}.${sourceOutput} → ${targetInstance}.${targetInput}`,
         };
       } catch (err: unknown) {
-        const msg = errorMessage(err);
-        const notFound =
-          msg.toLowerCase().includes('not found') || msg.toLowerCase().includes('unknown');
         return {
-          content: `Failed to connect: ${msg}${notFound ? '\nUse lace_inspect_node on each instance to see exact output/input names. Instance IDs come from the canvas snapshot.' : ''}`,
+          content: `Failed to connect: ${errorMessage(err)}`,
           isError: true,
         };
       }
@@ -390,10 +425,12 @@ export function registerGraphWriteTools(registry: ToolRegistry, deps: GraphWrite
       if ('error' in engineResult) return engineResult.error;
 
       try {
-        await engineResult.client.disconnect({
-          target: targetInstance,
-          input_name: inputName,
+        const result = await applyAction(engineResult.client, {
+          disconnect: { target: targetInstance, input_name: inputName },
         });
+        if (!result.success) {
+          return { content: `Failed to disconnect: ${applyReason(result)}`, isError: true };
+        }
         return { content: `Disconnected input "${inputName}" on instance "${targetInstance}".` };
       } catch (err: unknown) {
         return { content: `Failed to disconnect: ${errorMessage(err)}`, isError: true };
@@ -456,8 +493,8 @@ export function registerGraphWriteTools(registry: ToolRegistry, deps: GraphWrite
 
       let mode: string;
       let value: unknown;
-      let variable: string | undefined;
-      let expression: string | undefined;
+      let variable = '';
+      let expression = '';
 
       if (hasValue) {
         mode = 'literal';
@@ -474,14 +511,19 @@ export function registerGraphWriteTools(registry: ToolRegistry, deps: GraphWrite
       if ('error' in engineResult) return engineResult.error;
 
       try {
-        await engineResult.client.updateInput({
-          instance_id: instanceId,
-          input_name: inputName,
-          mode,
-          value,
-          variable,
-          expression,
+        const result = await applyAction(engineResult.client, {
+          update_input: {
+            instance_id: instanceId,
+            input_name: inputName,
+            mode: modeToInputMode(mode),
+            value,
+            variable,
+            expression,
+          },
         });
+        if (!result.success) {
+          return { content: `Failed to set input: ${applyReason(result)}`, isError: true };
+        }
 
         const desc =
           mode === 'literal'
@@ -539,7 +581,15 @@ export function registerGraphWriteTools(registry: ToolRegistry, deps: GraphWrite
       if ('error' in engineResult) return engineResult.error;
 
       try {
-        await engineResult.client.renameInstance({ old_id: oldId, new_id: newId });
+        const result = await applyAction(engineResult.client, {
+          rename_instance: { old_id: oldId, new_id: newId },
+        });
+        if (!result.success) {
+          return {
+            content: `Failed to rename instance: ${applyReason(result)}`,
+            isError: true,
+          };
+        }
 
         const lines = [`Renamed instance "${oldId}" to "${newId}".`];
 
@@ -605,25 +655,30 @@ export function registerGraphWriteTools(registry: ToolRegistry, deps: GraphWrite
       }
 
       const required = typeof params.required === 'boolean' ? params.required : true;
-      const description = typeof params.description === 'string' ? params.description : undefined;
+      const description = typeof params.description === 'string' ? params.description : '';
       const defaultValue = params.default !== undefined ? params.default : undefined;
 
       const engineResult = requireEngine(deps.getRpcClient);
       if ('error' in engineResult) return engineResult.error;
 
-      // Get existing variables, update or add the one specified
       try {
-        await engineResult.client.setVariables({
-          variables: [
-            {
-              name: varName,
-              type: varType,
-              required,
-              description,
-              default: defaultValue,
-            },
-          ],
+        const result = await applyAction(engineResult.client, {
+          set_variables: {
+            variables: [
+              {
+                name: varName,
+                type: varType,
+                required,
+                description,
+                default_value: defaultValue,
+                validation: undefined,
+              },
+            ],
+          },
         });
+        if (!result.success) {
+          return { content: `Failed to set variable: ${applyReason(result)}`, isError: true };
+        }
 
         const reqLabel = required ? 'required' : 'optional';
         const defLabel =
@@ -654,9 +709,18 @@ export function registerGraphWriteTools(registry: ToolRegistry, deps: GraphWrite
       if ('error' in engineResult) return engineResult.error;
 
       try {
-        const canvasView = await engineResult.client.undo();
+        const { result, view } = await applyActionAndAwaitView(
+          engineResult.client,
+          { undo: {} },
+          deps.awaitNextView,
+        );
+        if (!result.success) {
+          return { content: `Failed to undo: ${applyReason(result)}`, isError: true };
+        }
+        const nodeCount = view?.nodes.length ?? 0;
+        const edgeCount = view?.edges.length ?? 0;
         return {
-          content: `Undone. Canvas now has ${canvasView.nodes.length} instance(s) and ${canvasView.edges.length} connection(s).`,
+          content: `Undone. Canvas now has ${nodeCount} instance(s) and ${edgeCount} connection(s).`,
         };
       } catch (err: unknown) {
         return { content: `Failed to undo: ${errorMessage(err)}`, isError: true };
@@ -708,16 +772,35 @@ export function registerGraphWriteTools(registry: ToolRegistry, deps: GraphWrite
       const client = engineResult.client;
 
       try {
-        // Read existing locals, merge, then write back (setLocals replaces the full array)
+        // Read existing locals, merge, then write back (set_locals replaces the full array).
+        // SettingsConfig exposes locals as { name, mode, value_display } (display form);
+        // set_locals' LocalEntry is { name, mode, value, variable, expression }. For
+        // other entries we're preserving, route value_display into the field matching
+        // the mode. Exact round-trip is imperfect for complex literals — a read-typed
+        // surface would be cleaner, but ships the write path correctly in the meantime.
         const settings = await client.querySettings();
-        const existingLocals = (settings.locals ?? []).filter((l) => l.name !== name);
+        const preserved = (settings.locals ?? [])
+          .filter((l) => l.name !== name)
+          .map((l) => ({
+            name: l.name,
+            mode: l.mode,
+            value: l.mode === 'literal' ? (l.value_display as unknown) : undefined,
+            variable: '',
+            expression: l.mode !== 'literal' ? l.value_display : '',
+          }));
         const newLocal = {
           name,
           mode: hasExpression ? 'expression' : 'literal',
           value: hasValue ? value : undefined,
-          expression: hasExpression ? expression : undefined,
+          variable: '',
+          expression: hasExpression ? (expression as string) : '',
         };
-        await client.setLocals({ locals: [...existingLocals, newLocal] });
+        const result = await applyAction(client, {
+          set_locals: { locals: [...preserved, newLocal] },
+        });
+        if (!result.success) {
+          return { content: `Failed to set local: ${applyReason(result)}`, isError: true };
+        }
 
         const display = hasExpression
           ? `expression \`${expression}\``
@@ -775,7 +858,12 @@ export function registerGraphWriteTools(registry: ToolRegistry, deps: GraphWrite
           ...existingEnvs,
           [environment]: { ...(existingEnvs[environment] ?? {}), ...variables },
         };
-        await client.setEnvironments({ environments: mergedEnvs });
+        const result = await applyAction(client, {
+          set_environments: { environments: mergedEnvs, environment_backends: {} },
+        });
+        if (!result.success) {
+          return { content: `Failed to set environment: ${applyReason(result)}`, isError: true };
+        }
 
         const keys = Object.keys(variables).join(', ');
         return {
@@ -829,12 +917,16 @@ export function registerGraphWriteTools(registry: ToolRegistry, deps: GraphWrite
 
       try {
         const existingGroupIds = new Set((deps.getCanvasView()?.groups ?? []).map((g) => g.id));
-        const canvasView = await engineResult.client.createGroup({
-          label,
-          node_ids: instanceIds,
-        });
+        const { result, view } = await applyActionAndAwaitView(
+          engineResult.client,
+          { create_group: { label, node_ids: instanceIds } },
+          deps.awaitNextView,
+        );
+        if (!result.success) {
+          return { content: `Failed to create group: ${applyReason(result)}`, isError: true };
+        }
 
-        const newGroup = canvasView.groups.find((g) => !existingGroupIds.has(g.id));
+        const newGroup = view?.groups.find((g) => !existingGroupIds.has(g.id));
         const groupId = newGroup?.id ?? 'unknown';
         return {
           content: `Created group "${label}" (id: ${groupId}) with ${instanceIds.length} instances: ${instanceIds.join(', ')}.`,
@@ -873,7 +965,12 @@ export function registerGraphWriteTools(registry: ToolRegistry, deps: GraphWrite
       if ('error' in engineResult) return engineResult.error;
 
       try {
-        await engineResult.client.deleteGroup({ group_id: groupId });
+        const result = await applyAction(engineResult.client, {
+          delete_group: { group_id: groupId },
+        });
+        if (!result.success) {
+          return { content: `Failed to ungroup: ${applyReason(result)}`, isError: true };
+        }
         return { content: `Removed group "${groupId}". All instances remain on the canvas.` };
       } catch (err: unknown) {
         return { content: `Failed to ungroup: ${errorMessage(err)}`, isError: true };

--- a/packages/chat-sidebar/src/host/tools/helpers.ts
+++ b/packages/chat-sidebar/src/host/tools/helpers.ts
@@ -3,7 +3,8 @@
 // Shared helpers for chat tool implementations.
 
 import type { ToolResult } from '@lace-cloud/chat-core';
-import type { LaceTransport } from '@lace-cloud/host';
+import type { Action, BundleApplyResult, LaceTransport } from '@lace-cloud/host';
+import type { CanvasView } from '@lace-cloud/proto';
 
 const ENGINE_NOT_RUNNING: ToolResult = {
   content:
@@ -27,4 +28,50 @@ export function requireEngine(
 /** Extract error message from unknown error. */
 export function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Apply a single action through the single ApplyAction RPC. Post-P10 this
+ * is the only mutation surface; per-method transport helpers no longer
+ * exist. Returns the BundleApplyResult (success flag + validation errors).
+ */
+export async function applyAction(
+  client: LaceTransport,
+  action: Action,
+): Promise<BundleApplyResult> {
+  return client.applyAction([action]);
+}
+
+/**
+ * Apply an action, then wait for the post-mutation BundleState to arrive
+ * on the Subscribe stream (via ChatController.awaitNextView). Used by
+ * tools that must observe the post-mutation view (e.g., placeModule
+ * finding the new instance's id). The caller must wire `awaitNextView`
+ * through deps; it's set up before the RPC so no event is missed.
+ *
+ * On mutation failure, the waiter is discarded and the call short-circuits
+ * with `{ success: false, errors, view: null }` — there is no
+ * post-mutation state to wait for.
+ */
+export async function applyActionAndAwaitView(
+  client: LaceTransport,
+  action: Action,
+  awaitNextView: () => Promise<CanvasView | null>,
+): Promise<{ result: BundleApplyResult; view: CanvasView | null }> {
+  // Arm the waiter BEFORE sending the action — if we armed after, a
+  // fast Subscribe broadcast could arrive before the waiter is in the
+  // queue and we'd hang.
+  const viewPromise = awaitNextView();
+  const result = await applyAction(client, action);
+  if (!result.success) {
+    return { result, view: null };
+  }
+  const view = await viewPromise;
+  return { result, view };
+}
+
+/** Format a BundleApplyResult's errors as a human-readable reason. */
+export function applyReason(result: BundleApplyResult): string {
+  if (result.success) return '';
+  return result.errors.map((e) => e.message).join('; ') || 'unknown validation error';
 }

--- a/packages/chat-sidebar/src/host/view-provider.ts
+++ b/packages/chat-sidebar/src/host/view-provider.ts
@@ -1,5 +1,5 @@
 import * as path from 'node:path';
-import type { CanvasView } from '@lace-cloud/host';
+import type { CanvasView } from '@lace-cloud/proto';
 import * as vscode from 'vscode';
 import { ChatController, type ChatSidebarDeps } from './controller';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,20 +12,29 @@ importers:
         specifier: ^1.12.6
         version: 1.14.3
       '@lace-cloud/canvas':
-        specifier: ^0.1.1
-        version: 0.1.1(@types/react@18.3.28)
+        specifier: 0.1.1-next.24828814947
+        version: 0.1.1-next.24828814947(@types/react@18.3.28)
+      '@lace-cloud/chat-core':
+        specifier: 0.1.1-next.24828814947
+        version: 0.1.1-next.24828814947
       '@lace-cloud/chat-sidebar':
         specifier: workspace:*
         version: link:packages/chat-sidebar
       '@lace-cloud/chat-webview':
-        specifier: ^0.1.1
-        version: 0.1.1
+        specifier: 0.1.1-next.24828814947
+        version: 0.1.1-next.24828814947
       '@lace-cloud/design-tokens':
-        specifier: ^0.1.1
-        version: 0.1.1
+        specifier: 0.1.1-next.24828814947
+        version: 0.1.1-next.24828814947
       '@lace-cloud/host':
-        specifier: ^0.1.1
-        version: 0.1.1
+        specifier: 0.1.1-next.24828814947
+        version: 0.1.1-next.24828814947
+      '@lace-cloud/proto':
+        specifier: 0.1.1-next.24828814947
+        version: 0.1.1-next.24828814947
+      '@lace-cloud/ui':
+        specifier: 0.1.1-next.24828814947
+        version: 0.1.1-next.24828814947
       '@xyflow/react':
         specifier: ^12.10.1
         version: 12.10.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -97,20 +106,20 @@ importers:
   packages/chat-sidebar:
     dependencies:
       '@lace-cloud/chat-core':
-        specifier: ^0.1.1
-        version: 0.1.1
+        specifier: 0.1.1-next.24828814947
+        version: 0.1.1-next.24828814947
       '@lace-cloud/chat-webview':
-        specifier: ^0.1.1
-        version: 0.1.1
+        specifier: 0.1.1-next.24828814947
+        version: 0.1.1-next.24828814947
       '@lace-cloud/design-tokens':
-        specifier: ^0.1.1
-        version: 0.1.1
+        specifier: 0.1.1-next.24828814947
+        version: 0.1.1-next.24828814947
       '@lace-cloud/host':
-        specifier: ^0.1.1
-        version: 0.1.1
+        specifier: 0.1.1-next.24828814947
+        version: 0.1.1-next.24828814947
       '@lace-cloud/proto':
-        specifier: ^0.1.1
-        version: 0.1.1
+        specifier: 0.1.1-next.24828814947
+        version: 0.1.1-next.24828814947
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -617,26 +626,26 @@ packages:
     peerDependencies:
       tslib: '2'
 
-  '@lace-cloud/canvas@0.1.1':
-    resolution: {integrity: sha512-xg5bznuM9IGkboighEomXtArcDGfFmOMBVA/ifgCLn6jKEiwO5R/K51qdDRo5nq2y/Xxhqb2K+DUaYJcczBbYw==, tarball: https://npm.pkg.github.com/download/@lace-cloud/canvas/0.1.1/10998f34db350c08905be65ed9eff945f773ccee}
+  '@lace-cloud/canvas@0.1.1-next.24828814947':
+    resolution: {integrity: sha512-+hSEcPi2ABh0EYta3xr6nyvNA+yDYYDaI+eRAvI0Cul9YIP41ln5uXngabFp5b8Zwvu4rxcvf1vJOgY0tassvQ==, tarball: https://npm.pkg.github.com/download/@lace-cloud/canvas/0.1.1-next.24828814947/55a9e9a03cff48f32136a317aa9c51dd83075798}
 
-  '@lace-cloud/chat-core@0.1.1':
-    resolution: {integrity: sha512-P8ALhrpGjjKJ1Z/7znUGiWw/lyKEqwEaxDWgFHc3neyNqB/DSoccg/IXMyAPff11VSOqjoX9LIsgklUAfmft8Q==, tarball: https://npm.pkg.github.com/download/@lace-cloud/chat-core/0.1.1/1a2d2519049685a06db5adb597b615b09f0fd0d0}
+  '@lace-cloud/chat-core@0.1.1-next.24828814947':
+    resolution: {integrity: sha512-1sUGzTb+pHAqzb05za/pQmFF3muK13uKfLtSp8PKY2ugzU5JLoJuRKLjh9RbiYQGwn7XPZC9BaayXO3ik5q00Q==, tarball: https://npm.pkg.github.com/download/@lace-cloud/chat-core/0.1.1-next.24828814947/69f1ef5b2cfcd6778d070039033c7be82d70f5ee}
 
-  '@lace-cloud/chat-webview@0.1.1':
-    resolution: {integrity: sha512-e2yQjlFH+MTZ6eBMbDBaJzG9H8Utf1CsubF7X5rEKDKyhBea59JOuXnVg55nC7MW24ZEB8IhqSN0kLl41zYmDw==, tarball: https://npm.pkg.github.com/download/@lace-cloud/chat-webview/0.1.1/8bf913b2cc14b73bb9326498f8cd2d88b00f61ce}
+  '@lace-cloud/chat-webview@0.1.1-next.24828814947':
+    resolution: {integrity: sha512-06oqdo/yp1OUxCChCjWDc2zfwzKWakhBadEbxEFhbkK1qFWEviaKwxn2SpQU8Af3bAx6RQ1aGrUM+WBOyiI3Dw==, tarball: https://npm.pkg.github.com/download/@lace-cloud/chat-webview/0.1.1-next.24828814947/cf5b9508dd61cb650d1f3948e74b0f3e4029f53f}
 
-  '@lace-cloud/design-tokens@0.1.1':
-    resolution: {integrity: sha512-WFwYdhN7ihzo0Djibt0T6yog4KZviPt0OvKVQWDLrcpUn9fdBNYa/xydv/GHHzTysCxkLiWSR1yBtlSkOO1wTA==, tarball: https://npm.pkg.github.com/download/@lace-cloud/design-tokens/0.1.1/8d51259d72b32691ff65a9ab05f74b76a8e8000f}
+  '@lace-cloud/design-tokens@0.1.1-next.24828814947':
+    resolution: {integrity: sha512-zz36Ro4pVtj3bw1TtPCT2PoGo4JZZovEs2dK4iKuY/vIvW4py2CGrNLsCJSA9pYtvsqidqwyAXwgCjf4TClZ3A==, tarball: https://npm.pkg.github.com/download/@lace-cloud/design-tokens/0.1.1-next.24828814947/909ccce977bfeb90624da1f47842af99e41f76bc}
 
-  '@lace-cloud/host@0.1.1':
-    resolution: {integrity: sha512-mJFh2Yf322ifjTmpmlnjlX1GnpvoD5YLOAnoKDlTKBoDBZzQkDcJXxhtQ88uVUBbcoxpcC2PiE2px5B+Uot+UA==, tarball: https://npm.pkg.github.com/download/@lace-cloud/host/0.1.1/68d72c87f724689d39b431506cf43bff3b2cb0a1}
+  '@lace-cloud/host@0.1.1-next.24828814947':
+    resolution: {integrity: sha512-R3QAZ0rJ/v4gAEvFARdlu23jn2RhnOr+lmw5Wnhw5Xn1ReWOmHKJRA0VhqbnX+bpN9RqVxe/gFuaSpnkYKlaOw==, tarball: https://npm.pkg.github.com/download/@lace-cloud/host/0.1.1-next.24828814947/21edbd3139d28a403d43a471f21d072297a0cb64}
 
-  '@lace-cloud/proto@0.1.1':
-    resolution: {integrity: sha512-vU8PxcYxgFv5vgMarWjmjW71hc/AXJyD6gSiagSz+yRkquQ11zXxfBM3U4VMFH1jebtrEgryDsVtvbDDm10FZg==, tarball: https://npm.pkg.github.com/download/@lace-cloud/proto/0.1.1/5c01495162260e126a0381148ad0ffee89863662}
+  '@lace-cloud/proto@0.1.1-next.24828814947':
+    resolution: {integrity: sha512-MSjcQwGk5vf6xfV1dzeeqbr7mEvcMNwAUMkuPmhuAX1dybcoKondIPNLN8LiGk85dZfp5HWsP/KCSphH0yN1VA==, tarball: https://npm.pkg.github.com/download/@lace-cloud/proto/0.1.1-next.24828814947/fa667d7a507d4e278b9ab10b7f99cf812d394402}
 
-  '@lace-cloud/ui@0.1.1':
-    resolution: {integrity: sha512-tTkH+XfVwSd7Zqd+yXCEwJueMv8TISiKP1bjl/tpc6/9lTmvWkk2mpl/pL1C+3UJbiPuykONmhggmlX2+iRYFA==, tarball: https://npm.pkg.github.com/download/@lace-cloud/ui/0.1.1/bbe77244ab260e876c258f76aea4830d40b51655}
+  '@lace-cloud/ui@0.1.1-next.24828814947':
+    resolution: {integrity: sha512-3FFJoUO+DasUB//CrLQUik0xOf2dnzA0VTruJT71YBr5MbgH9zdWv+Qggjpq1Vxe11TOelKU1/s4akThBHUnCQ==, tarball: https://npm.pkg.github.com/download/@lace-cloud/ui/0.1.1-next.24828814947/a5c29096710040ed1049657bef326ea34c5b1a58}
 
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
@@ -3622,11 +3631,11 @@ snapshots:
       '@jsonjoy.com/codegen': 17.67.0(tslib@2.8.1)
       tslib: 2.8.1
 
-  '@lace-cloud/canvas@0.1.1(@types/react@18.3.28)':
+  '@lace-cloud/canvas@0.1.1-next.24828814947(@types/react@18.3.28)':
     dependencies:
       '@bufbuild/protobuf': 2.11.0
-      '@lace-cloud/proto': 0.1.1
-      '@lace-cloud/ui': 0.1.1
+      '@lace-cloud/proto': 0.1.1-next.24828814947
+      '@lace-cloud/ui': 0.1.1-next.24828814947
       '@xyflow/react': 12.10.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -3634,33 +3643,33 @@ snapshots:
       - '@types/react'
       - immer
 
-  '@lace-cloud/chat-core@0.1.1':
+  '@lace-cloud/chat-core@0.1.1-next.24828814947':
     dependencies:
-      '@lace-cloud/host': 0.1.1
-      '@lace-cloud/proto': 0.1.1
+      '@lace-cloud/host': 0.1.1-next.24828814947
+      '@lace-cloud/proto': 0.1.1-next.24828814947
 
-  '@lace-cloud/chat-webview@0.1.1':
+  '@lace-cloud/chat-webview@0.1.1-next.24828814947':
     dependencies:
-      '@lace-cloud/chat-core': 0.1.1
-      '@lace-cloud/design-tokens': 0.1.1
+      '@lace-cloud/chat-core': 0.1.1-next.24828814947
+      '@lace-cloud/design-tokens': 0.1.1-next.24828814947
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@lace-cloud/design-tokens@0.1.1': {}
+  '@lace-cloud/design-tokens@0.1.1-next.24828814947': {}
 
-  '@lace-cloud/host@0.1.1':
+  '@lace-cloud/host@0.1.1-next.24828814947':
     dependencies:
       '@bufbuild/protobuf': 2.11.0
       '@grpc/grpc-js': 1.14.3
-      '@lace-cloud/proto': 0.1.1
+      '@lace-cloud/proto': 0.1.1-next.24828814947
 
-  '@lace-cloud/proto@0.1.1':
+  '@lace-cloud/proto@0.1.1-next.24828814947':
     dependencies:
       '@bufbuild/protobuf': 2.11.0
 
-  '@lace-cloud/ui@0.1.1':
+  '@lace-cloud/ui@0.1.1-next.24828814947':
     dependencies:
-      '@lace-cloud/design-tokens': 0.1.1
+      '@lace-cloud/design-tokens': 0.1.1-next.24828814947
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 

--- a/src/deploy/cli.ts
+++ b/src/deploy/cli.ts
@@ -1,0 +1,155 @@
+// Thin shell wrapper around the `lace` CLI for Deploy-panel operations.
+// The extension does not maintain its own control-plane API client;
+// instead it reuses the CLI's existing auth + HTTP layer via subprocess
+// calls with `--output json`. This keeps auth centralized in the CLI
+// (tokens, org/team context, refresh) and avoids duplicating the API
+// surface in the extension.
+
+import { type ChildProcess, spawn } from 'node:child_process';
+import * as vscode from 'vscode';
+
+export type Stack = {
+  id: string;
+  slug: string;
+  name: string;
+  description?: string;
+  orgId: string;
+  teamId: string;
+  connectionId: string;
+  createdAt: string;
+};
+
+export type Run = {
+  id: string;
+  stackId: string;
+  kind: string;
+  status: string;
+  bundleSnapshotId: string;
+  initiatedByUserId: string;
+  initiatedVia: string;
+  planResourceAdd?: number;
+  planResourceChange?: number;
+  planResourceDestroy?: number;
+  changeRequestId?: string | null;
+  startedAt: string;
+  completedAt?: string | null;
+  errorMessage?: string | null;
+};
+
+function getBinaryPath(): string {
+  return vscode.workspace.getConfiguration('lace').get<string>('binaryPath', 'lace');
+}
+
+/**
+ * Run `lace ...args` and return parsed JSON stdout. Non-zero exit
+ * throws with the stderr as message.
+ */
+async function runCliJson<T>(args: string[]): Promise<T> {
+  const bin = getBinaryPath();
+  return new Promise<T>((resolve, reject) => {
+    const p = spawn(bin, [...args, '--output', 'json'], { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    p.stdout.on('data', (d) => {
+      stdout += d.toString();
+    });
+    p.stderr.on('data', (d) => {
+      stderr += d.toString();
+    });
+    p.on('error', reject);
+    p.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(stderr.trim() || `lace ${args.join(' ')} exited ${code}`));
+        return;
+      }
+      try {
+        resolve(JSON.parse(stdout) as T);
+      } catch (err) {
+        reject(new Error(`Failed to parse CLI JSON output: ${(err as Error).message}`));
+      }
+    });
+  });
+}
+
+export async function listStacks(): Promise<Stack[]> {
+  const res = await runCliJson<{ stacks?: Stack[] } | Stack[]>(['stack', 'list']);
+  if (Array.isArray(res)) return res;
+  return res.stacks ?? [];
+}
+
+export async function listRuns(stackId: string, limit = 10): Promise<Run[]> {
+  const res = await runCliJson<{ runs?: Run[] } | Run[]>([
+    'run',
+    'list',
+    '--stack',
+    stackId,
+    '--limit',
+    String(limit),
+  ]);
+  if (Array.isArray(res)) return res;
+  return res.runs ?? [];
+}
+
+export async function getRun(runId: string): Promise<Run> {
+  return runCliJson<Run>(['run', 'get', runId]);
+}
+
+/**
+ * Spawn `lace run apply <stack>` in a VS Code Terminal. The terminal
+ * surfaces progress (plan, policy evaluation, run creation) directly
+ * to the user; terminal remains open for them to inspect output.
+ * Returns the terminal handle so callers can watch for exit.
+ */
+export function spawnApply(stackId: string, cwd: string): vscode.Terminal {
+  const bin = getBinaryPath();
+  const terminal = vscode.window.createTerminal({
+    name: `Lace: apply ${stackId.slice(0, 12)}`,
+    cwd,
+  });
+  terminal.show();
+  terminal.sendText(`${quote(bin)} run apply ${quote(stackId)}`);
+  return terminal;
+}
+
+/**
+ * Spawn `lace run logs --follow <runId>` as a background process and
+ * pipe its stdout/stderr lines to the provided OutputChannel.
+ * Returns a disposable that stops the stream.
+ */
+export function streamRunLogs(
+  runId: string,
+  channel: vscode.OutputChannel,
+): { dispose: () => void; process: ChildProcess } {
+  const bin = getBinaryPath();
+  const proc = spawn(bin, ['run', 'logs', '--follow', runId], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  proc.stdout?.on('data', (d: Buffer) => channel.append(d.toString()));
+  proc.stderr?.on('data', (d: Buffer) => channel.append(d.toString()));
+  proc.on('close', (code) => {
+    channel.appendLine(`\n[stream ended, exit=${code}]`);
+  });
+  return {
+    process: proc,
+    dispose: () => {
+      if (!proc.killed) proc.kill('SIGTERM');
+    },
+  };
+}
+
+function quote(arg: string): string {
+  return `'${arg.replace(/'/g, "'\\''")}'`;
+}
+
+export const TERMINAL_RUN_STATUSES = new Set([
+  'apply_succeeded',
+  'apply_failed',
+  'plan_failed',
+  'policy_blocked',
+  'cancelled',
+  'rejected',
+]);
+
+export function isTerminal(status: string): boolean {
+  return TERMINAL_RUN_STATUSES.has(status);
+}

--- a/src/deploy/deploy-panel-provider.ts
+++ b/src/deploy/deploy-panel-provider.ts
@@ -1,0 +1,346 @@
+// Deploy panel: a WebviewView that lets the user pick a stack and
+// trigger `lace run apply` for it. The panel holds the stack picker
+// + the apply button + a status line for the most-recent run; the
+// recent-runs TreeView lives as a sibling view in the same
+// container.
+//
+// Architecture note: the extension shells out to the CLI for every
+// control-plane operation (see deploy/cli.ts for the rationale).
+// No direct HTTP to the API; auth stays in the CLI.
+
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import { buildWebviewHtml } from '../vscode/webview-html';
+import {
+  getRun,
+  isTerminal,
+  listRuns,
+  listStacks,
+  type Run,
+  type Stack,
+  spawnApply,
+  streamRunLogs,
+} from './cli';
+import type { RunsTreeProvider } from './runs-tree-provider';
+
+const POLL_INTERVAL_MS = 2000;
+
+type StateSnapshot = {
+  stacks: Stack[];
+  activeStackId: string | null;
+  activeRun: Run | null;
+  errorMessage: string | null;
+};
+
+export class DeployPanelProvider implements vscode.WebviewViewProvider {
+  public static readonly viewType = 'laceDeploy';
+
+  private view: vscode.WebviewView | null = null;
+  private stacks: Stack[] = [];
+  private activeStackId: string | null = null;
+  private activeRun: Run | null = null;
+  private errorMessage: string | null = null;
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+  private logChannels = new Map<string, vscode.OutputChannel>();
+  private logStreams = new Map<string, { dispose: () => void }>();
+
+  constructor(
+    private readonly context: vscode.ExtensionContext,
+    private readonly runsTree: RunsTreeProvider,
+  ) {}
+
+  resolveWebviewView(view: vscode.WebviewView): void {
+    view.webview.options = {
+      enableScripts: true,
+      localResourceRoots: [
+        vscode.Uri.file(path.join(this.context.extensionPath, 'out')),
+        vscode.Uri.joinPath(this.context.extensionUri, 'images'),
+      ],
+    };
+    view.webview.html = this.buildHtml(view.webview);
+    this.view = view;
+
+    view.webview.onDidReceiveMessage(async (msg) => {
+      switch (msg.command) {
+        case 'ready':
+          await this.refreshStacks();
+          this.postSnapshot();
+          break;
+        case 'selectStack':
+          this.setActiveStack((msg.stackId as string) || null);
+          break;
+        case 'apply':
+          this.triggerApply();
+          break;
+        case 'refreshStacks':
+          await this.refreshStacks();
+          this.postSnapshot();
+          break;
+        case 'openRunInPortal':
+          this.openRunInPortal(msg.runId as string);
+          break;
+      }
+    });
+
+    view.onDidDispose(() => {
+      this.view = null;
+      this.stopPolling();
+      for (const stream of this.logStreams.values()) stream.dispose();
+      this.logStreams.clear();
+    });
+  }
+
+  showRun(runId: string): void {
+    this.openRunInPortal(runId);
+  }
+
+  private buildHtml(webview: vscode.Webview): string {
+    // Inline a minimal React-free webview — the deploy panel is form-shaped,
+    // no canvas, no shared UI components. Keeping it script-minimal avoids
+    // pulling the rspack chain through another bundle.
+    const nonce = Math.random().toString(36).slice(2);
+    const script = `
+      const vscode = acquireVsCodeApi();
+      const $ = (id) => document.getElementById(id);
+
+      vscode.postMessage({ command: 'ready' });
+
+      window.addEventListener('message', (ev) => {
+        const msg = ev.data;
+        if (msg?.command === 'snapshot') renderSnapshot(msg.state);
+      });
+
+      function renderSnapshot(state) {
+        const picker = $('stack-picker');
+        picker.innerHTML = '';
+        const empty = document.createElement('option');
+        empty.value = '';
+        empty.textContent = '— select a stack —';
+        picker.appendChild(empty);
+        for (const s of state.stacks) {
+          const opt = document.createElement('option');
+          opt.value = s.id;
+          opt.textContent = s.slug + ' — ' + s.name;
+          if (s.id === state.activeStackId) opt.selected = true;
+          picker.appendChild(opt);
+        }
+        $('apply-btn').disabled = !state.activeStackId;
+        const err = $('error');
+        err.style.display = state.errorMessage ? 'block' : 'none';
+        err.textContent = state.errorMessage || '';
+
+        const run = $('active-run');
+        if (state.activeRun) {
+          const r = state.activeRun;
+          run.style.display = 'block';
+          $('run-id').textContent = r.id;
+          $('run-status').textContent = r.status;
+          $('run-kind').textContent = r.kind;
+          const counts = 'adds ' + (r.planResourceAdd || 0) +
+                         ', changes ' + (r.planResourceChange || 0) +
+                         ', destroys ' + (r.planResourceDestroy || 0);
+          $('run-counts').textContent = counts;
+          $('portal-btn').style.display = r.status === 'awaiting_approval' ? 'inline-block' : 'none';
+        } else {
+          run.style.display = 'none';
+        }
+      }
+
+      $('stack-picker').addEventListener('change', (ev) => {
+        vscode.postMessage({ command: 'selectStack', stackId: ev.target.value });
+      });
+      $('apply-btn').addEventListener('click', () => {
+        vscode.postMessage({ command: 'apply' });
+      });
+      $('refresh-btn').addEventListener('click', () => {
+        vscode.postMessage({ command: 'refreshStacks' });
+      });
+      $('portal-btn').addEventListener('click', () => {
+        const id = $('run-id').textContent;
+        if (id) vscode.postMessage({ command: 'openRunInPortal', runId: id });
+      });
+    `.trim();
+
+    const body = `
+      <style>
+        body { font-family: var(--vscode-font-family); padding: 12px; color: var(--vscode-foreground); }
+        label { display: block; margin-top: 10px; font-size: 12px; color: var(--vscode-descriptionForeground); }
+        select, button { width: 100%; padding: 6px 10px; margin-top: 4px; background: var(--vscode-button-secondaryBackground); color: var(--vscode-button-secondaryForeground); border: 1px solid var(--vscode-contrastBorder, transparent); border-radius: 3px; }
+        button.primary { background: var(--vscode-button-background); color: var(--vscode-button-foreground); }
+        button:disabled { opacity: 0.5; cursor: not-allowed; }
+        .row { margin-top: 14px; }
+        .error { background: var(--vscode-inputValidation-errorBackground); border: 1px solid var(--vscode-inputValidation-errorBorder); padding: 6px 8px; margin-top: 10px; font-size: 12px; display: none; }
+        .run { background: var(--vscode-textBlockQuote-background); border: 1px solid var(--vscode-panel-border); padding: 10px; margin-top: 14px; display: none; border-radius: 3px; font-size: 12px; }
+        .run strong { display: block; font-size: 11px; color: var(--vscode-descriptionForeground); margin-top: 6px; }
+        .run code { font-family: var(--vscode-editor-font-family); font-size: 11px; }
+        .portal-btn { margin-top: 8px; display: none; }
+      </style>
+      <div>
+        <label for="stack-picker">Stack</label>
+        <select id="stack-picker"></select>
+        <div class="row">
+          <button id="apply-btn" class="primary" disabled>Apply</button>
+        </div>
+        <div class="row">
+          <button id="refresh-btn">Refresh stacks</button>
+        </div>
+        <div class="error" id="error"></div>
+        <div class="run" id="active-run">
+          <strong>Current run</strong>
+          <div><code id="run-id"></code></div>
+          <div>Kind: <code id="run-kind"></code></div>
+          <div>Status: <code id="run-status"></code></div>
+          <div><code id="run-counts"></code></div>
+          <button id="portal-btn" class="portal-btn">Open in portal</button>
+        </div>
+      </div>
+    `.trim();
+
+    // Reuse the extension's shared HTML scaffold for CSP + nonce, but
+    // inline the body + script via a data: URL since buildWebviewHtml
+    // expects a file-backed script. Simpler path: hand-roll the HTML.
+    void buildWebviewHtml;
+    const csp = [
+      "default-src 'none'",
+      `style-src ${webview.cspSource} 'unsafe-inline'`,
+      `script-src 'nonce-${nonce}'`,
+      `img-src ${webview.cspSource} https: data:`,
+      `font-src ${webview.cspSource}`,
+    ].join('; ');
+    return `<!DOCTYPE html><html><head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="${csp}">
+  <title>Lace Deploy</title>
+</head><body>
+  ${body}
+  <script nonce="${nonce}">${script}</script>
+</body></html>`;
+  }
+
+  private async refreshStacks(): Promise<void> {
+    try {
+      this.stacks = await listStacks();
+      this.errorMessage = null;
+    } catch (err) {
+      this.errorMessage = err instanceof Error ? err.message : String(err);
+      this.stacks = [];
+    }
+  }
+
+  private setActiveStack(stackId: string | null): void {
+    if (stackId === this.activeStackId) return;
+    this.activeStackId = stackId;
+    this.activeRun = null;
+    this.stopPolling();
+    this.runsTree.setStack(stackId);
+    this.postSnapshot();
+  }
+
+  private triggerApply(): void {
+    if (!this.activeStackId) return;
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    if (!workspaceFolder) {
+      vscode.window.showErrorMessage('Open a workspace folder first.');
+      return;
+    }
+    const terminal = spawnApply(this.activeStackId, workspaceFolder.uri.fsPath);
+    // The terminal exits when `lace run apply` finishes; we refresh the
+    // runs list on close to pull in the new run row.
+    const disposable = vscode.window.onDidCloseTerminal((t) => {
+      if (t === terminal) {
+        disposable.dispose();
+        void this.pickupLatestRun();
+      }
+    });
+  }
+
+  private async pickupLatestRun(): Promise<void> {
+    if (!this.activeStackId) return;
+    await this.runsTree.refresh();
+    try {
+      const runs = await listRuns(this.activeStackId, 1);
+      const latest = runs[0] ?? null;
+      if (latest) this.setActiveRun(latest);
+    } catch (err) {
+      this.errorMessage = err instanceof Error ? err.message : String(err);
+      this.postSnapshot();
+    }
+  }
+
+  private setActiveRun(run: Run): void {
+    this.activeRun = run;
+    this.startLogStream(run.id);
+    this.postSnapshot();
+    if (!isTerminal(run.status)) {
+      this.startPolling();
+    } else {
+      this.stopPolling();
+    }
+  }
+
+  private startPolling(): void {
+    if (this.pollTimer) return;
+    this.pollTimer = setInterval(async () => {
+      if (!this.activeRun) {
+        this.stopPolling();
+        return;
+      }
+      try {
+        const run = await getRun(this.activeRun.id);
+        this.activeRun = run;
+        this.postSnapshot();
+        if (isTerminal(run.status)) this.stopPolling();
+      } catch (err) {
+        this.errorMessage = err instanceof Error ? err.message : String(err);
+        this.postSnapshot();
+      }
+    }, POLL_INTERVAL_MS);
+  }
+
+  private stopPolling(): void {
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+  }
+
+  private startLogStream(runId: string): void {
+    if (this.logStreams.has(runId)) return;
+    let channel = this.logChannels.get(runId);
+    if (!channel) {
+      channel = vscode.window.createOutputChannel(`Lace: run ${runId.slice(0, 12)}`);
+      this.logChannels.set(runId, channel);
+    }
+    channel.show(true);
+    const stream = streamRunLogs(runId, channel);
+    this.logStreams.set(runId, stream);
+  }
+
+  private openRunInPortal(runId: string): void {
+    const configured = vscode.workspace.getConfiguration('lace').get<string>('portalUrl', '');
+    if (!configured) {
+      vscode.window.showInformationMessage(
+        'Set `lace.portalUrl` to your Lace portal URL to enable "Open in portal".',
+      );
+      return;
+    }
+    // The portal route is /{org}/{team}/stacks/{stackId}/runs/{runId}.
+    // We don't know org/team from the run alone; point at the top-level
+    // runs search and let the user navigate. Refinement: resolve
+    // org/team from `lace stack get <stackId>` when we need direct
+    // deep-linking.
+    const base = configured.replace(/\/$/, '');
+    void vscode.env.openExternal(vscode.Uri.parse(`${base}/runs/${runId}`));
+  }
+
+  private postSnapshot(): void {
+    if (!this.view) return;
+    const snapshot: StateSnapshot = {
+      stacks: this.stacks,
+      activeStackId: this.activeStackId,
+      activeRun: this.activeRun,
+      errorMessage: this.errorMessage,
+    };
+    this.view.webview.postMessage({ command: 'snapshot', state: snapshot });
+  }
+}

--- a/src/deploy/runs-tree-provider.ts
+++ b/src/deploy/runs-tree-provider.ts
@@ -1,0 +1,112 @@
+// TreeView showing recent runs for the Deploy panel's active stack.
+// Clicking a run opens its portal detail page. Refresh pulls the
+// latest list from `lace run list`.
+
+import * as vscode from 'vscode';
+import { listRuns, type Run } from './cli';
+
+const STATUS_ICON: Record<string, string> = {
+  plan_succeeded: 'check',
+  plan_failed: 'error',
+  policy_eval: 'sync~spin',
+  policy_blocked: 'error',
+  auto_apply: 'sync~spin',
+  awaiting_approval: 'question',
+  approved: 'check',
+  applying: 'sync~spin',
+  apply_succeeded: 'pass-filled',
+  apply_failed: 'error',
+  cancelled: 'circle-slash',
+  rejected: 'error',
+};
+
+export class RunTreeItem extends vscode.TreeItem {
+  constructor(public readonly run: Run) {
+    super(`${run.kind} · ${run.id.slice(0, 12)}`, vscode.TreeItemCollapsibleState.None);
+    const plan = run.planResourceAdd ?? 0;
+    const chg = run.planResourceChange ?? 0;
+    const dst = run.planResourceDestroy ?? 0;
+    this.description = `${run.status} · +${plan} ~${chg} -${dst}`;
+    this.tooltip = [
+      `Run: ${run.id}`,
+      `Kind: ${run.kind}`,
+      `Status: ${run.status}`,
+      `Started: ${run.startedAt}`,
+      run.completedAt ? `Completed: ${run.completedAt}` : null,
+      run.errorMessage ? `Error: ${run.errorMessage}` : null,
+    ]
+      .filter(Boolean)
+      .join('\n');
+    this.iconPath = new vscode.ThemeIcon(STATUS_ICON[run.status] ?? 'circle-outline');
+    this.contextValue = run.status;
+    this.command = {
+      command: 'lace.deploy.showRun',
+      title: 'Show run',
+      arguments: [run.id],
+    };
+  }
+}
+
+export class RunsTreeProvider implements vscode.TreeDataProvider<RunTreeItem> {
+  private readonly _onDidChangeTreeData = new vscode.EventEmitter<void>();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  private stackId: string | null = null;
+  private runs: Run[] = [];
+  private loading = false;
+  private loadError: string | null = null;
+
+  setStack(stackId: string | null): void {
+    if (stackId === this.stackId) return;
+    this.stackId = stackId;
+    this.runs = [];
+    this.loadError = null;
+    this._onDidChangeTreeData.fire();
+    if (stackId) void this.refresh();
+  }
+
+  async refresh(): Promise<void> {
+    if (!this.stackId || this.loading) return;
+    this.loading = true;
+    this.loadError = null;
+    try {
+      this.runs = await listRuns(this.stackId, 10);
+    } catch (err) {
+      this.loadError = err instanceof Error ? err.message : String(err);
+      this.runs = [];
+    } finally {
+      this.loading = false;
+      this._onDidChangeTreeData.fire();
+    }
+  }
+
+  getTreeItem(element: RunTreeItem): vscode.TreeItem {
+    return element;
+  }
+
+  getChildren(): vscode.ProviderResult<RunTreeItem[]> {
+    if (!this.stackId) {
+      const item = new vscode.TreeItem('No stack selected', vscode.TreeItemCollapsibleState.None);
+      item.description = 'Pick a stack in the Deploy panel.';
+      return [item as RunTreeItem];
+    }
+    if (this.loading && this.runs.length === 0) {
+      const item = new vscode.TreeItem('Loading…', vscode.TreeItemCollapsibleState.None);
+      return [item as RunTreeItem];
+    }
+    if (this.loadError) {
+      const item = new vscode.TreeItem(
+        `Error: ${this.loadError}`,
+        vscode.TreeItemCollapsibleState.None,
+      );
+      item.iconPath = new vscode.ThemeIcon('error');
+      return [item as RunTreeItem];
+    }
+    if (this.runs.length === 0) {
+      const item = new vscode.TreeItem('No runs yet', vscode.TreeItemCollapsibleState.None);
+      item.description = 'Use the Apply button in the Deploy panel.';
+      return [item as RunTreeItem];
+    }
+    return this.runs.map((r) => new RunTreeItem(r));
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,8 @@
 import { ChatViewProvider } from '@lace-cloud/chat-sidebar';
 import { type RegistryModule, ServerManager } from '@lace-cloud/host';
 import * as vscode from 'vscode';
+import { DeployPanelProvider } from './deploy/deploy-panel-provider';
+import { RunsTreeProvider } from './deploy/runs-tree-provider';
 import {
   addModuleToActiveCanvas,
   getLaceDir,
@@ -218,6 +220,18 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.window.registerWebviewViewProvider(ChatViewProvider.viewType, chatViewProvider),
     vscode.commands.registerCommand('lace.clearChatHistory', () => chatViewProvider.clearHistory()),
+  );
+
+  // ── Deploy panel (Arc P5) ──
+  const runsTreeProvider = new RunsTreeProvider();
+  const deployPanelProvider = new DeployPanelProvider(context, runsTreeProvider);
+  context.subscriptions.push(
+    vscode.window.registerWebviewViewProvider(DeployPanelProvider.viewType, deployPanelProvider),
+    vscode.window.registerTreeDataProvider('laceDeployRuns', runsTreeProvider),
+    vscode.commands.registerCommand('lace.deploy.refreshRuns', () => runsTreeProvider.refresh()),
+    vscode.commands.registerCommand('lace.deploy.showRun', (runId: string) =>
+      deployPanelProvider.showRun(runId),
+    ),
   );
 }
 

--- a/src/vscode/canvas-panel.ts
+++ b/src/vscode/canvas-panel.ts
@@ -1,7 +1,6 @@
 import * as path from 'node:path';
 import {
-  type CanvasView,
-  type Diagnostic,
+  type BundleState,
   type HostToWebview,
   type LaceTransport,
   requireClient,
@@ -17,21 +16,7 @@ const LACE_DIR = '.lace';
 
 let canvasPanel: vscode.WebviewPanel | undefined;
 let isGenerating = false;
-let latestCanvasView: CanvasView | undefined;
 let subscribeHandler: SubscribeHandler | null = null;
-
-function isCanvasView(value: unknown): value is CanvasView {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'nodes' in value &&
-    Array.isArray((value as CanvasView).nodes)
-  );
-}
-
-export function getLatestCanvasView(): CanvasView | undefined {
-  return latestCanvasView;
-}
 
 export function getLaceDir(): string | undefined {
   const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
@@ -41,11 +26,6 @@ export function getLaceDir(): string | undefined {
 
 function postToWebview(panel: vscode.WebviewPanel, msg: HostToWebview) {
   panel.webview.postMessage(msg);
-}
-
-export function publishCanvasViewToActivePanel(state: CanvasView): void {
-  if (!canvasPanel) return;
-  postToWebview(canvasPanel, { command: 'loadState', state });
 }
 
 function requireTransport(server: ServerManager, action: string): LaceTransport {
@@ -63,19 +43,28 @@ export async function addModuleToActiveCanvas(
     vscode.window.showWarningMessage('No canvas open.');
     return;
   }
-  const panel = canvasPanel;
   await vscode.window.withProgress(
     { location: vscode.ProgressLocation.Notification, title: `Adding ${name}...` },
     async () => {
       try {
         const transport = requireTransport(server, 'place module');
-        const view = await transport.placeModule({ name, system, version, organization });
-        latestCanvasView = view;
-        postToWebview(panel, {
-          command: 'loadState',
-          state: view,
-          viewportIntent: { kind: 'fit-all', padding: 0.2, duration: 300 },
-        });
+        const result = await transport.applyAction([
+          {
+            place_module: {
+              name,
+              system,
+              version,
+              organization: organization ?? '',
+              position: undefined,
+            },
+          },
+        ]);
+        if (!result.success) {
+          const reason = result.errors.map((e) => e.message).join('; ') || 'unknown';
+          vscode.window.showErrorMessage(`Add module rejected: ${reason}`);
+        }
+        // Post-mutation BundleState arrives via Subscribe and is
+        // forwarded to the webview automatically; no optimistic push.
       } catch (err: unknown) {
         handleRpcError(err, 'placeModule', 'add module to canvas');
       }
@@ -97,7 +86,7 @@ export async function triggerGenerateOnActiveCanvas(server: ServerManager) {
       output_dir: laceDir,
       options: { dry_run: false, format: true, validate: true, overwrite: true },
     });
-    const errors = (result?.diagnostics ?? []).filter((d: Diagnostic) => d.severity === 'error');
+    const errors = (result?.diagnostics ?? []).filter((d) => d.severity === 'error');
     if (errors.length > 0) {
       postToWebview(panel, {
         command: 'generateError',
@@ -131,8 +120,6 @@ window.addEventListener('DOMContentLoaded', () => {
 });
 `.trim();
 
-// Body bg uses the user's editor background so the brief flash before
-// the React canvas mounts theme-matches VS Code (light/dark/HC).
 const CANVAS_BODY_STYLE = `body { margin: 0; padding: 0; height: 100vh; background: var(--vscode-editor-background); display: flex; flex-direction: column; }`;
 
 export async function openCanvas(context: vscode.ExtensionContext, server: ServerManager) {
@@ -199,25 +186,27 @@ export async function openCanvas(context: vscode.ExtensionContext, server: Serve
   });
   const safetyTimeout = setTimeout(resolveReady!, 10_000);
 
+  function forwardState(state: BundleState) {
+    postToWebview(panel, { command: 'loadState', state });
+  }
+
   panel.webview.onDidReceiveMessage(
     async (msg: WebviewToHost | { command: string; [key: string]: unknown }) => {
       switch (msg.command) {
         case 'webviewReady': {
           try {
             const transport = requireTransport(server, 'session/open');
-            const { view } = await transport.sessionOpen({
+            const { state } = await transport.sessionOpen({
               file_path: laceDir,
               workspace_name: folderName,
             });
-            latestCanvasView = view;
-            postToWebview(panel, { command: 'loadState', state: view });
+            forwardState(state);
             const sessionId = transport.sessionId;
             if (sessionId) {
               subscribeHandler = new SubscribeHandler();
               subscribeHandler.start(transport.subscribeStream(sessionId), {
-                onStateUpdated: (v) => {
-                  latestCanvasView = v;
-                  postToWebview(panel, { command: 'loadState', state: v });
+                onStateUpdated: (nextState) => {
+                  forwardState(nextState);
                 },
                 onGenerateProgress: (stage) => {
                   postToWebview(panel, {
@@ -257,7 +246,6 @@ export async function openCanvas(context: vscode.ExtensionContext, server: Serve
           try {
             const transport = requireTransport(server, method);
             const result = await transport.dispatch(method, params);
-            if (isCanvasView(result)) latestCanvasView = result;
             postToWebview(panel, { command: 'engineResult', requestId, result });
           } catch (err: unknown) {
             postToWebview(panel, {


### PR DESCRIPTION
## Summary
- New **Deploy** webview: stack picker + Apply button + active-run status card with status polling + Open-in-portal deep-link for awaiting-approval runs.
- New **Recent runs** TreeView: status-badged list of the selected stack's last 10 runs; clicking a row opens it in the portal.
- **Log streaming**: per-run OutputChannel piped from `lace run logs --follow`.
- Shells out to CLI for all control-plane ops (`lace stack list`, `lace run apply`, `lace run list`, `lace run get`, `lace run logs`). No direct `/api/v1/*` calls; auth stays in the CLI.

## Deliberate scope
Awaiting-approval CR **canvas preview** is deferred. Inline rendering needs an authed extension-side API client (to fetch bundle + layouts bytes for `SnapshotCanvasEngine`). v1 routes those users to the portal. Follow-up when the API client lands.

## Verification
- [x] `npx tsc --noEmit` clean
- [x] `pnpm run lint` clean
- [x] `pnpm run test:unit` 68/68 pass
- [x] `pnpm run build` green

## New surface
- Views: `laceDeploy`, `laceDeployRuns`
- Commands: `lace.deploy.refreshRuns`, `lace.deploy.showRun`
- Config: `lace.portalUrl` (base URL for portal deep-links)

## Plan reference
Arc P5 — see `~/.claude/plans/drifting-bubbling-sparrow.md` §E2.

## Depends on
- E1 (#107) merged to develop. This PR's diff is on top of #107's changes; rebase after E1 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)