### PR TITLE
fix: close Arc P10 E1/E2 residue

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,6 +157,16 @@
           "type": "string",
           "default": "",
           "description": "Base URL of your Lace portal (e.g., https://portal.lace.cloud). Used for 'Open in portal' deep-links in the Deploy panel. Leave empty to disable."
+        },
+        "lace.organization": {
+          "type": "string",
+          "default": "",
+          "description": "Default organization slug (mirrors the LACE_ORGANIZATION env var / --org flag the CLI uses). Used to construct portal deep-links."
+        },
+        "lace.team": {
+          "type": "string",
+          "default": "",
+          "description": "Default team slug (mirrors the LACE_TEAM env var / --team flag the CLI uses). Used to construct portal deep-links."
         }
       }
     },

--- a/packages/chat-sidebar/src/__tests__/test-utils/vscode-mock.ts
+++ b/packages/chat-sidebar/src/__tests__/test-utils/vscode-mock.ts
@@ -75,6 +75,26 @@ export function createVscodeMock() {
     }
   }
 
+  // ── TreeView primitives ──
+  // Used by deploy/runs-tree-provider. Instances are compared
+  // structurally in tests; the mock mirrors the shape rather than
+  // any behaviour.
+  class TreeItem {
+    description: string | undefined;
+    tooltip: string | undefined;
+    iconPath: unknown;
+    contextValue: string | undefined;
+    command: unknown;
+    constructor(
+      public label: string,
+      public collapsibleState: number = 0,
+    ) {}
+  }
+  const TreeItemCollapsibleState = { None: 0, Collapsed: 1, Expanded: 2 };
+  class ThemeIcon {
+    constructor(public id: string) {}
+  }
+
   return {
     LanguageModelTextPart,
     LanguageModelToolCallPart,
@@ -82,6 +102,9 @@ export function createVscodeMock() {
     LanguageModelChatMessage,
     LanguageModelChatMessageRole: { User: 1, Assistant: 2 },
     EventEmitter,
+    TreeItem,
+    TreeItemCollapsibleState,
+    ThemeIcon,
     workspace: {
       workspaceFolders: undefined as
         | undefined

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -122,4 +122,43 @@ module.exports = [
     },
     devtool: 'source-map',
   },
+  {
+    // Frontend (Webview) — deploy panel. Form-shaped UI (stack picker,
+    // apply button, status card); no React dependency, but built through
+    // the same rspack pipeline so the shared webview-html scaffold can
+    // reference out/deploy-webview.js by filename.
+    mode: 'development',
+    entry: './src/deploy-webview-entry.ts',
+    output: {
+      path: path.resolve(__dirname, 'out'),
+      filename: 'deploy-webview.js',
+    },
+    target: 'web',
+    resolve: {
+      extensions: ['.ts', '.js'],
+    },
+    module: {
+      rules: [
+        {
+          test: /\.ts$/,
+          use: {
+            loader: 'ts-loader',
+            options: {
+              configFile: path.resolve(__dirname, 'tsconfig.json'),
+              compilerOptions: { noEmit: false },
+            },
+          },
+          exclude: /node_modules/,
+        },
+      ],
+    },
+    optimization: {
+      runtimeChunk: false,
+      splitChunks: false,
+    },
+    experiments: {
+      css: false,
+    },
+    devtool: 'source-map',
+  },
 ];

--- a/src/deploy-webview-entry.ts
+++ b/src/deploy-webview-entry.ts
@@ -1,0 +1,165 @@
+// Deploy webview bootstrap — renders the stack-picker / apply-button /
+// active-run status card inside the VS Code webview and proxies user
+// actions back to the host via postMessage. The matching host provider
+// is src/deploy/deploy-panel-provider.ts.
+//
+// Shape is form-centric (select + buttons + a status card), so the UI
+// is plain DOM rather than React. Keeps the bundle small and avoids
+// pulling @lace-cloud/canvas through a non-canvas view.
+
+import type { DeployPanelMessage, DeployStateSnapshot } from './deploy/messages';
+
+type VsCodeApi = {
+  postMessage(msg: DeployPanelMessage): void;
+};
+
+declare global {
+  interface Window {
+    acquireVsCodeApi?: () => VsCodeApi;
+  }
+}
+
+const vscode = window.acquireVsCodeApi?.();
+
+const $ = (id: string): HTMLElement | null => document.getElementById(id);
+
+function mount(): void {
+  const root = $('root');
+  if (!root) return;
+  root.innerHTML = `
+    <style>
+      :host, body, .deploy-root { box-sizing: border-box; }
+      .deploy-root { padding: 12px; font-family: var(--vscode-font-family); color: var(--vscode-foreground); }
+      label { display: block; margin-top: 10px; font-size: 12px; color: var(--vscode-descriptionForeground); }
+      select, button {
+        width: 100%; padding: 6px 10px; margin-top: 4px; box-sizing: border-box;
+        background: var(--vscode-button-secondaryBackground);
+        color: var(--vscode-button-secondaryForeground);
+        border: 1px solid var(--vscode-contrastBorder, transparent);
+        border-radius: 3px;
+        font-family: inherit;
+      }
+      button.primary {
+        background: var(--vscode-button-background);
+        color: var(--vscode-button-foreground);
+      }
+      button:disabled { opacity: 0.5; cursor: not-allowed; }
+      .row { margin-top: 14px; }
+      .error {
+        background: var(--vscode-inputValidation-errorBackground);
+        border: 1px solid var(--vscode-inputValidation-errorBorder);
+        padding: 6px 8px;
+        margin-top: 10px;
+        font-size: 12px;
+        display: none;
+      }
+      .run {
+        background: var(--vscode-textBlockQuote-background);
+        border: 1px solid var(--vscode-panel-border);
+        padding: 10px;
+        margin-top: 14px;
+        display: none;
+        border-radius: 3px;
+        font-size: 12px;
+      }
+      .run strong {
+        display: block;
+        font-size: 11px;
+        color: var(--vscode-descriptionForeground);
+        margin-top: 6px;
+      }
+      .run code {
+        font-family: var(--vscode-editor-font-family);
+        font-size: 11px;
+      }
+      .portal-btn { margin-top: 8px; display: none; }
+    </style>
+    <div class="deploy-root">
+      <label for="stack-picker">Stack</label>
+      <select id="stack-picker"></select>
+      <div class="row">
+        <button id="apply-btn" class="primary" disabled>Apply</button>
+      </div>
+      <div class="row">
+        <button id="refresh-btn">Refresh stacks</button>
+      </div>
+      <div class="error" id="error"></div>
+      <div class="run" id="active-run">
+        <strong>Current run</strong>
+        <div><code id="run-id"></code></div>
+        <div>Kind: <code id="run-kind"></code></div>
+        <div>Status: <code id="run-status"></code></div>
+        <div><code id="run-counts"></code></div>
+        <button id="portal-btn" class="portal-btn">Open in portal</button>
+      </div>
+    </div>
+  `;
+
+  $('stack-picker')?.addEventListener('change', (ev) => {
+    const target = ev.target as HTMLSelectElement;
+    vscode?.postMessage({ command: 'selectStack', stackId: target.value || null });
+  });
+  $('apply-btn')?.addEventListener('click', () => {
+    vscode?.postMessage({ command: 'apply' });
+  });
+  $('refresh-btn')?.addEventListener('click', () => {
+    vscode?.postMessage({ command: 'refreshStacks' });
+  });
+  $('portal-btn')?.addEventListener('click', () => {
+    const id = $('run-id')?.textContent;
+    if (id) vscode?.postMessage({ command: 'openRunInPortal', runId: id });
+  });
+
+  vscode?.postMessage({ command: 'ready' });
+}
+
+function renderSnapshot(state: DeployStateSnapshot): void {
+  const picker = $('stack-picker') as HTMLSelectElement | null;
+  if (!picker) return;
+  picker.innerHTML = '';
+  const empty = document.createElement('option');
+  empty.value = '';
+  empty.textContent = '— select a stack —';
+  picker.appendChild(empty);
+  for (const s of state.stacks) {
+    const opt = document.createElement('option');
+    opt.value = s.id;
+    opt.textContent = `${s.slug} — ${s.name}`;
+    if (s.id === state.activeStackId) opt.selected = true;
+    picker.appendChild(opt);
+  }
+  const applyBtn = $('apply-btn') as HTMLButtonElement | null;
+  if (applyBtn) applyBtn.disabled = !state.activeStackId;
+
+  const errBox = $('error') as HTMLDivElement | null;
+  if (errBox) {
+    errBox.style.display = state.errorMessage ? 'block' : 'none';
+    errBox.textContent = state.errorMessage ?? '';
+  }
+
+  const runBox = $('active-run') as HTMLDivElement | null;
+  if (runBox && state.activeRun) {
+    const r = state.activeRun;
+    runBox.style.display = 'block';
+    ($('run-id') as HTMLElement).textContent = r.id;
+    ($('run-status') as HTMLElement).textContent = r.status;
+    ($('run-kind') as HTMLElement).textContent = r.kind;
+    const counts = `adds ${r.planResourceAdd ?? 0}, changes ${r.planResourceChange ?? 0}, destroys ${r.planResourceDestroy ?? 0}`;
+    ($('run-counts') as HTMLElement).textContent = counts;
+    const portalBtn = $('portal-btn') as HTMLButtonElement;
+    portalBtn.style.display = r.status === 'awaiting_approval' ? 'inline-block' : 'none';
+  } else if (runBox) {
+    runBox.style.display = 'none';
+  }
+}
+
+window.addEventListener('message', (ev) => {
+  const msg = ev.data as { command?: string; state?: DeployStateSnapshot };
+  if (msg?.command === 'snapshot' && msg.state) renderSnapshot(msg.state);
+});
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', mount);
+} else {
+  mount();
+}

--- a/src/deploy/__tests__/cli.test.ts
+++ b/src/deploy/__tests__/cli.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test, vi } from 'vitest';
+import { createVscodeMock } from '../../../packages/chat-sidebar/src/__tests__/test-utils/vscode-mock';
+
+vi.mock('vscode', () => createVscodeMock());
+
+import { isTerminal, TERMINAL_RUN_STATUSES } from '../cli';
+
+describe('isTerminal', () => {
+  test('recognizes all terminal statuses', () => {
+    for (const s of TERMINAL_RUN_STATUSES) {
+      expect(isTerminal(s)).toBe(true);
+    }
+  });
+
+  test('non-terminal statuses return false', () => {
+    for (const s of ['auto_apply', 'applying', 'awaiting_approval', 'plan_succeeded', '']) {
+      expect(isTerminal(s)).toBe(false);
+    }
+  });
+
+  test('unknown status returns false', () => {
+    expect(isTerminal('not_a_real_status')).toBe(false);
+  });
+});
+
+describe('TERMINAL_RUN_STATUSES', () => {
+  test('covers the apply+policy+cancel terminal states', () => {
+    expect(TERMINAL_RUN_STATUSES.has('apply_succeeded')).toBe(true);
+    expect(TERMINAL_RUN_STATUSES.has('apply_failed')).toBe(true);
+    expect(TERMINAL_RUN_STATUSES.has('plan_failed')).toBe(true);
+    expect(TERMINAL_RUN_STATUSES.has('policy_blocked')).toBe(true);
+    expect(TERMINAL_RUN_STATUSES.has('cancelled')).toBe(true);
+    expect(TERMINAL_RUN_STATUSES.has('rejected')).toBe(true);
+  });
+
+  test('does not include in-flight states', () => {
+    expect(TERMINAL_RUN_STATUSES.has('applying')).toBe(false);
+    expect(TERMINAL_RUN_STATUSES.has('awaiting_approval')).toBe(false);
+    expect(TERMINAL_RUN_STATUSES.has('plan_succeeded')).toBe(false);
+  });
+});

--- a/src/deploy/__tests__/runs-tree-provider.test.ts
+++ b/src/deploy/__tests__/runs-tree-provider.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { createVscodeMock } from '../../../packages/chat-sidebar/src/__tests__/test-utils/vscode-mock';
+
+vi.mock('vscode', () => createVscodeMock());
+vi.mock('../cli', () => ({
+  listRuns: vi.fn(),
+}));
+
+import { listRuns } from '../cli';
+import { RunsTreeProvider } from '../runs-tree-provider';
+
+describe('RunsTreeProvider', () => {
+  beforeEach(() => {
+    vi.mocked(listRuns).mockReset();
+  });
+
+  test('initial state shows "No stack selected"', async () => {
+    const provider = new RunsTreeProvider();
+    const children = await provider.getChildren();
+    expect(children).toHaveLength(1);
+    expect((children as Array<{ label: string }>)[0]!.label).toBe('No stack selected');
+    expect(listRuns).not.toHaveBeenCalled();
+  });
+
+  test('setStack triggers a refresh and populates runs', async () => {
+    vi.mocked(listRuns).mockResolvedValue([
+      {
+        id: 'run_1',
+        stackId: 'stk_x',
+        kind: 'apply',
+        status: 'apply_succeeded',
+        bundleSnapshotId: 'bs_abc',
+        initiatedByUserId: 'u1',
+        initiatedVia: 'cli',
+        planResourceAdd: 2,
+        planResourceChange: 1,
+        planResourceDestroy: 0,
+        startedAt: '2026-04-22T00:00:00Z',
+      },
+    ]);
+    const provider = new RunsTreeProvider();
+    // setStack kicks an async refresh — await the listRuns mock resolution.
+    provider.setStack('stk_x');
+    await vi.waitFor(() => expect(listRuns).toHaveBeenCalledWith('stk_x', 10));
+
+    const children = (await provider.getChildren()) as Array<{
+      label: string;
+      description?: string;
+    }>;
+    expect(children).toHaveLength(1);
+    expect(children[0]!.label).toContain('apply · run_1');
+    expect(children[0]!.description).toContain('apply_succeeded');
+  });
+
+  test('setStack(null) clears runs and shows no-stack placeholder', async () => {
+    vi.mocked(listRuns).mockResolvedValue([]);
+    const provider = new RunsTreeProvider();
+    provider.setStack('stk_x');
+    await vi.waitFor(() => expect(listRuns).toHaveBeenCalled());
+    provider.setStack(null);
+    const children = (await provider.getChildren()) as Array<{ label: string }>;
+    expect(children[0]!.label).toBe('No stack selected');
+  });
+
+  test('shows error placeholder when listRuns throws', async () => {
+    vi.mocked(listRuns).mockRejectedValue(new Error('engine unreachable'));
+    const provider = new RunsTreeProvider();
+    provider.setStack('stk_y');
+    await vi.waitFor(() => expect(listRuns).toHaveBeenCalled());
+    const children = (await provider.getChildren()) as Array<{ label: string }>;
+    expect(children[0]!.label).toContain('engine unreachable');
+  });
+
+  test('shows no-runs placeholder when the list is empty', async () => {
+    vi.mocked(listRuns).mockResolvedValue([]);
+    const provider = new RunsTreeProvider();
+    provider.setStack('stk_z');
+    await vi.waitFor(() => expect(listRuns).toHaveBeenCalled());
+    const children = (await provider.getChildren()) as Array<{ label: string }>;
+    expect(children[0]!.label).toBe('No runs yet');
+  });
+
+  test('refresh() re-fetches without changing the selected stack', async () => {
+    vi.mocked(listRuns).mockResolvedValue([]);
+    const provider = new RunsTreeProvider();
+    provider.setStack('stk_z');
+    await vi.waitFor(() => expect(listRuns).toHaveBeenCalledTimes(1));
+    await provider.refresh();
+    expect(listRuns).toHaveBeenCalledTimes(2);
+    const [firstCall, secondCall] = vi.mocked(listRuns).mock.calls;
+    expect(firstCall![0]).toBe(secondCall![0]);
+  });
+});

--- a/src/deploy/deploy-panel-provider.ts
+++ b/src/deploy/deploy-panel-provider.ts
@@ -4,9 +4,9 @@
 // recent-runs TreeView lives as a sibling view in the same
 // container.
 //
-// Architecture note: the extension shells out to the CLI for every
-// control-plane operation (see deploy/cli.ts for the rationale).
-// No direct HTTP to the API; auth stays in the CLI.
+// Architecture: the extension shells out to the CLI for every
+// control-plane operation (see deploy/cli.ts). No direct HTTP to
+// the API; auth stays in the CLI.
 
 import * as path from 'node:path';
 import * as vscode from 'vscode';
@@ -21,16 +21,10 @@ import {
   spawnApply,
   streamRunLogs,
 } from './cli';
+import type { DeployHostMessage, DeployPanelMessage, DeployStateSnapshot } from './messages';
 import type { RunsTreeProvider } from './runs-tree-provider';
 
 const POLL_INTERVAL_MS = 2000;
-
-type StateSnapshot = {
-  stacks: Stack[];
-  activeStackId: string | null;
-  activeRun: Run | null;
-  errorMessage: string | null;
-};
 
 export class DeployPanelProvider implements vscode.WebviewViewProvider {
   public static readonly viewType = 'laceDeploy';
@@ -43,6 +37,7 @@ export class DeployPanelProvider implements vscode.WebviewViewProvider {
   private pollTimer: ReturnType<typeof setInterval> | null = null;
   private logChannels = new Map<string, vscode.OutputChannel>();
   private logStreams = new Map<string, { dispose: () => void }>();
+  private applyStartedAt: number | null = null;
 
   constructor(
     private readonly context: vscode.ExtensionContext,
@@ -57,17 +52,20 @@ export class DeployPanelProvider implements vscode.WebviewViewProvider {
         vscode.Uri.joinPath(this.context.extensionUri, 'images'),
       ],
     };
-    view.webview.html = this.buildHtml(view.webview);
+    view.webview.html = buildWebviewHtml(this.context, view.webview, {
+      scriptFilename: 'deploy-webview.js',
+      title: 'Lace Deploy',
+    });
     this.view = view;
 
-    view.webview.onDidReceiveMessage(async (msg) => {
+    view.webview.onDidReceiveMessage(async (msg: DeployPanelMessage) => {
       switch (msg.command) {
         case 'ready':
           await this.refreshStacks();
           this.postSnapshot();
           break;
         case 'selectStack':
-          this.setActiveStack((msg.stackId as string) || null);
+          this.setActiveStack(msg.stackId);
           break;
         case 'apply':
           this.triggerApply();
@@ -77,7 +75,7 @@ export class DeployPanelProvider implements vscode.WebviewViewProvider {
           this.postSnapshot();
           break;
         case 'openRunInPortal':
-          this.openRunInPortal(msg.runId as string);
+          await this.openRunInPortal(msg.runId);
           break;
       }
     });
@@ -90,131 +88,23 @@ export class DeployPanelProvider implements vscode.WebviewViewProvider {
     });
   }
 
-  showRun(runId: string): void {
-    this.openRunInPortal(runId);
-  }
-
-  private buildHtml(webview: vscode.Webview): string {
-    // Inline a minimal React-free webview — the deploy panel is form-shaped,
-    // no canvas, no shared UI components. Keeping it script-minimal avoids
-    // pulling the rspack chain through another bundle.
-    const nonce = Math.random().toString(36).slice(2);
-    const script = `
-      const vscode = acquireVsCodeApi();
-      const $ = (id) => document.getElementById(id);
-
-      vscode.postMessage({ command: 'ready' });
-
-      window.addEventListener('message', (ev) => {
-        const msg = ev.data;
-        if (msg?.command === 'snapshot') renderSnapshot(msg.state);
-      });
-
-      function renderSnapshot(state) {
-        const picker = $('stack-picker');
-        picker.innerHTML = '';
-        const empty = document.createElement('option');
-        empty.value = '';
-        empty.textContent = '— select a stack —';
-        picker.appendChild(empty);
-        for (const s of state.stacks) {
-          const opt = document.createElement('option');
-          opt.value = s.id;
-          opt.textContent = s.slug + ' — ' + s.name;
-          if (s.id === state.activeStackId) opt.selected = true;
-          picker.appendChild(opt);
-        }
-        $('apply-btn').disabled = !state.activeStackId;
-        const err = $('error');
-        err.style.display = state.errorMessage ? 'block' : 'none';
-        err.textContent = state.errorMessage || '';
-
-        const run = $('active-run');
-        if (state.activeRun) {
-          const r = state.activeRun;
-          run.style.display = 'block';
-          $('run-id').textContent = r.id;
-          $('run-status').textContent = r.status;
-          $('run-kind').textContent = r.kind;
-          const counts = 'adds ' + (r.planResourceAdd || 0) +
-                         ', changes ' + (r.planResourceChange || 0) +
-                         ', destroys ' + (r.planResourceDestroy || 0);
-          $('run-counts').textContent = counts;
-          $('portal-btn').style.display = r.status === 'awaiting_approval' ? 'inline-block' : 'none';
-        } else {
-          run.style.display = 'none';
-        }
+  /**
+   * Loads a run as the panel's active run (pulls its metadata, opens a
+   * log stream, starts polling). Called by the Recent-runs TreeView
+   * when a row is clicked so the user can attach to a historical run
+   * without re-triggering an apply.
+   */
+  async showRun(runId: string): Promise<void> {
+    try {
+      const run = await getRun(runId);
+      this.setActiveRun(run);
+      if (this.activeStackId !== run.stackId) {
+        this.setActiveStack(run.stackId);
       }
-
-      $('stack-picker').addEventListener('change', (ev) => {
-        vscode.postMessage({ command: 'selectStack', stackId: ev.target.value });
-      });
-      $('apply-btn').addEventListener('click', () => {
-        vscode.postMessage({ command: 'apply' });
-      });
-      $('refresh-btn').addEventListener('click', () => {
-        vscode.postMessage({ command: 'refreshStacks' });
-      });
-      $('portal-btn').addEventListener('click', () => {
-        const id = $('run-id').textContent;
-        if (id) vscode.postMessage({ command: 'openRunInPortal', runId: id });
-      });
-    `.trim();
-
-    const body = `
-      <style>
-        body { font-family: var(--vscode-font-family); padding: 12px; color: var(--vscode-foreground); }
-        label { display: block; margin-top: 10px; font-size: 12px; color: var(--vscode-descriptionForeground); }
-        select, button { width: 100%; padding: 6px 10px; margin-top: 4px; background: var(--vscode-button-secondaryBackground); color: var(--vscode-button-secondaryForeground); border: 1px solid var(--vscode-contrastBorder, transparent); border-radius: 3px; }
-        button.primary { background: var(--vscode-button-background); color: var(--vscode-button-foreground); }
-        button:disabled { opacity: 0.5; cursor: not-allowed; }
-        .row { margin-top: 14px; }
-        .error { background: var(--vscode-inputValidation-errorBackground); border: 1px solid var(--vscode-inputValidation-errorBorder); padding: 6px 8px; margin-top: 10px; font-size: 12px; display: none; }
-        .run { background: var(--vscode-textBlockQuote-background); border: 1px solid var(--vscode-panel-border); padding: 10px; margin-top: 14px; display: none; border-radius: 3px; font-size: 12px; }
-        .run strong { display: block; font-size: 11px; color: var(--vscode-descriptionForeground); margin-top: 6px; }
-        .run code { font-family: var(--vscode-editor-font-family); font-size: 11px; }
-        .portal-btn { margin-top: 8px; display: none; }
-      </style>
-      <div>
-        <label for="stack-picker">Stack</label>
-        <select id="stack-picker"></select>
-        <div class="row">
-          <button id="apply-btn" class="primary" disabled>Apply</button>
-        </div>
-        <div class="row">
-          <button id="refresh-btn">Refresh stacks</button>
-        </div>
-        <div class="error" id="error"></div>
-        <div class="run" id="active-run">
-          <strong>Current run</strong>
-          <div><code id="run-id"></code></div>
-          <div>Kind: <code id="run-kind"></code></div>
-          <div>Status: <code id="run-status"></code></div>
-          <div><code id="run-counts"></code></div>
-          <button id="portal-btn" class="portal-btn">Open in portal</button>
-        </div>
-      </div>
-    `.trim();
-
-    // Reuse the extension's shared HTML scaffold for CSP + nonce, but
-    // inline the body + script via a data: URL since buildWebviewHtml
-    // expects a file-backed script. Simpler path: hand-roll the HTML.
-    void buildWebviewHtml;
-    const csp = [
-      "default-src 'none'",
-      `style-src ${webview.cspSource} 'unsafe-inline'`,
-      `script-src 'nonce-${nonce}'`,
-      `img-src ${webview.cspSource} https: data:`,
-      `font-src ${webview.cspSource}`,
-    ].join('; ');
-    return `<!DOCTYPE html><html><head>
-  <meta charset="UTF-8">
-  <meta http-equiv="Content-Security-Policy" content="${csp}">
-  <title>Lace Deploy</title>
-</head><body>
-  ${body}
-  <script nonce="${nonce}">${script}</script>
-</body></html>`;
+    } catch (err) {
+      this.errorMessage = err instanceof Error ? err.message : String(err);
+      this.postSnapshot();
+    }
   }
 
   private async refreshStacks(): Promise<void> {
@@ -243,9 +133,8 @@ export class DeployPanelProvider implements vscode.WebviewViewProvider {
       vscode.window.showErrorMessage('Open a workspace folder first.');
       return;
     }
+    this.applyStartedAt = Date.now();
     const terminal = spawnApply(this.activeStackId, workspaceFolder.uri.fsPath);
-    // The terminal exits when `lace run apply` finishes; we refresh the
-    // runs list on close to pull in the new run row.
     const disposable = vscode.window.onDidCloseTerminal((t) => {
       if (t === terminal) {
         disposable.dispose();
@@ -254,13 +143,26 @@ export class DeployPanelProvider implements vscode.WebviewViewProvider {
     });
   }
 
+  /**
+   * After the apply terminal closes, identify the run we just kicked
+   * off by correlating with the timestamp: the first run on the active
+   * stack with startedAt >= applyStartedAt is ours. If no run matches
+   * (apply errored before run creation), leave activeRun untouched so
+   * the user sees the last known state.
+   */
   private async pickupLatestRun(): Promise<void> {
     if (!this.activeStackId) return;
     await this.runsTree.refresh();
     try {
-      const runs = await listRuns(this.activeStackId, 1);
-      const latest = runs[0] ?? null;
-      if (latest) this.setActiveRun(latest);
+      const runs = await listRuns(this.activeStackId, 5);
+      const deadline = this.applyStartedAt;
+      const ours = deadline
+        ? runs.find((r) => {
+            const started = r.startedAt ? Date.parse(r.startedAt) : NaN;
+            return !Number.isNaN(started) && started >= deadline - 2000;
+          })
+        : runs[0];
+      if (ours) this.setActiveRun(ours);
     } catch (err) {
       this.errorMessage = err instanceof Error ? err.message : String(err);
       this.postSnapshot();
@@ -316,31 +218,53 @@ export class DeployPanelProvider implements vscode.WebviewViewProvider {
     this.logStreams.set(runId, stream);
   }
 
-  private openRunInPortal(runId: string): void {
-    const configured = vscode.workspace.getConfiguration('lace').get<string>('portalUrl', '');
-    if (!configured) {
+  /**
+   * Build the portal route for a run. Portal URL is
+   * `<portalUrl>/<org>/<team>/stacks/<stackId>/runs/<runId>` for
+   * general runs, and `.../change-requests/<crId>` for awaiting-
+   * approval runs where the user is expected to decide. Requires
+   * `lace.portalUrl`, `lace.organization`, and `lace.team` to be
+   * configured (the same values the CLI uses via its env/flags).
+   */
+  private async openRunInPortal(runId: string): Promise<void> {
+    const cfg = vscode.workspace.getConfiguration('lace');
+    const portalUrl = cfg.get<string>('portalUrl', '').replace(/\/$/, '');
+    const org = cfg.get<string>('organization', '');
+    const team = cfg.get<string>('team', '');
+    if (!portalUrl) {
       vscode.window.showInformationMessage(
-        'Set `lace.portalUrl` to your Lace portal URL to enable "Open in portal".',
+        'Set `lace.portalUrl` in settings to enable "Open in portal".',
       );
       return;
     }
-    // The portal route is /{org}/{team}/stacks/{stackId}/runs/{runId}.
-    // We don't know org/team from the run alone; point at the top-level
-    // runs search and let the user navigate. Refinement: resolve
-    // org/team from `lace stack get <stackId>` when we need direct
-    // deep-linking.
-    const base = configured.replace(/\/$/, '');
-    void vscode.env.openExternal(vscode.Uri.parse(`${base}/runs/${runId}`));
+    if (!org || !team) {
+      vscode.window.showInformationMessage(
+        'Set `lace.organization` and `lace.team` in settings to deep-link into the portal.',
+      );
+      return;
+    }
+    try {
+      const run = await getRun(runId);
+      const url = run.changeRequestId
+        ? `${portalUrl}/${org}/${team}/change-requests/${run.changeRequestId}`
+        : `${portalUrl}/${org}/${team}/stacks/${run.stackId}/runs/${run.id}`;
+      void vscode.env.openExternal(vscode.Uri.parse(url));
+    } catch (err) {
+      vscode.window.showErrorMessage(
+        `Could not resolve portal URL: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   private postSnapshot(): void {
     if (!this.view) return;
-    const snapshot: StateSnapshot = {
+    const snapshot: DeployStateSnapshot = {
       stacks: this.stacks,
       activeStackId: this.activeStackId,
       activeRun: this.activeRun,
       errorMessage: this.errorMessage,
     };
-    this.view.webview.postMessage({ command: 'snapshot', state: snapshot });
+    const message: DeployHostMessage = { command: 'snapshot', state: snapshot };
+    this.view.webview.postMessage(message);
   }
 }

--- a/src/deploy/messages.ts
+++ b/src/deploy/messages.ts
@@ -1,0 +1,24 @@
+// Shared message types for the deploy panel: the webview bootstrap
+// (src/deploy-webview-entry.ts) and the host provider
+// (src/deploy/deploy-panel-provider.ts) both import from here so the
+// postMessage contract is compiler-checked on both ends.
+
+import type { Run, Stack } from './cli';
+
+export type DeployStateSnapshot = {
+  stacks: Stack[];
+  activeStackId: string | null;
+  activeRun: Run | null;
+  errorMessage: string | null;
+};
+
+/** Messages the webview sends to the host. */
+export type DeployPanelMessage =
+  | { command: 'ready' }
+  | { command: 'selectStack'; stackId: string | null }
+  | { command: 'apply' }
+  | { command: 'refreshStacks' }
+  | { command: 'openRunInPortal'; runId: string };
+
+/** Messages the host sends to the webview. */
+export type DeployHostMessage = { command: 'snapshot'; state: DeployStateSnapshot };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -229,9 +229,9 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.window.registerWebviewViewProvider(DeployPanelProvider.viewType, deployPanelProvider),
     vscode.window.registerTreeDataProvider('laceDeployRuns', runsTreeProvider),
     vscode.commands.registerCommand('lace.deploy.refreshRuns', () => runsTreeProvider.refresh()),
-    vscode.commands.registerCommand('lace.deploy.showRun', (runId: string) =>
-      deployPanelProvider.showRun(runId),
-    ),
+    vscode.commands.registerCommand('lace.deploy.showRun', (runId: string) => {
+      void deployPanelProvider.showRun(runId);
+    }),
   );
 }
 

--- a/src/vscode/webview-html.ts
+++ b/src/vscode/webview-html.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 
@@ -22,7 +23,9 @@ export function buildWebviewHtml(
   webview: vscode.Webview,
   options: WebviewHtmlOptions,
 ): string {
-  const nonce = Math.random().toString(36).substring(2, 15);
+  // CSP nonces must be unpredictable. Math.random() isn't
+  // cryptographically strong; randomBytes is the right primitive.
+  const nonce = randomBytes(16).toString('hex');
   const scriptUri = webview.asWebviewUri(
     vscode.Uri.file(path.join(context.extensionPath, 'out', options.scriptFilename)),
   );

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,10 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['packages/chat-sidebar/src/__tests__/**/*.test.{ts,tsx}'],
+    include: [
+      'packages/chat-sidebar/src/__tests__/**/*.test.{ts,tsx}',
+      'src/**/__tests__/**/*.test.{ts,tsx}',
+    ],
     environment: 'node',
     passWithNoTests: true,
   },


### PR DESCRIPTION
## Summary
Post-merge audit of E1/E2 surfaced shortcut residue. This PR closes them.

## Commits
1. **ext: deploy panel uses shared webview scaffold + strong nonce + deep-link resolution**
   - Deploy webview moves from hand-rolled HTML to shared `buildWebviewHtml` + new `out/deploy-webview.js` rspack entry.
   - Shared `src/deploy/messages.ts` types the postMessage contract.
   - `crypto.randomBytes` replaces `Math.random()` for CSP nonces in every webview.
   - Portal deep-link now reads `lace.organization` + `lace.team` config and builds `/<org>/<team>/change-requests/<crId>` (awaiting-approval) or `.../stacks/<stackId>/runs/<runId>`.
   - TreeView click loads the run into the Deploy panel (sets active, starts log stream, polls status) instead of just opening portal.
   - `pickupLatestRun` correlates the applied run with the terminal's startedAt timestamp.
2. **test: vitest coverage for deploy/cli + deploy/runs-tree-provider** — 79/79 tests pass (+11).

## Intentional choice: no inline CR canvas preview
The awaiting-approval CR canvas preview (listed as E2 §4 in the original plan) is **not** rendered inline. Rationale: the portal already has `SnapshotCanvasPanel` rendering the bundle, and approval workflows need org-level context (team members, policy detail, multi-step chains) best served in the portal. The Deploy panel's "Open in portal" button now deep-links directly to the CR detail page. Inline rendering would require a new React-ified webview variant + authed byte fetch; out of cleanup scope.

## New VS Code config
- `lace.organization` — default org slug for portal deep-links (mirrors the CLI's `LACE_ORGANIZATION`).
- `lace.team` — default team slug.

## Verification
- [x] `pnpm test:unit` 79/79
- [x] `pnpm lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `pnpm run build` 4 bundles green (extension, canvas, chat, deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)