### PR TITLE
ci: automate dependabot PRs — group bumps + auto-merge minor/patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,83 @@
+# Dependabot configuration.
+#
+# - GitHub Actions bumps coalesce into one PR per directory per
+#   week via grouping.
+# - npm bumps split prod vs dev so devDependency churn doesn't
+#   block runtime bumps.
+# - @lace-cloud/* is ignored by Dependabot because the lace monorepo
+#   publishes those packages; we bump them manually against monorepo
+#   releases via `pnpm update '@lace-cloud/*' --latest`.
+#
+# Auto-merge of minor+patch happens in
+# .github/workflows/dependabot-auto-merge.yml — Dependabot opens
+# the PR, that workflow enables GitHub's --auto merge on green CI
+# for minor/patch. Majors stay open for review.
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - dependencies
+      - github-actions
+
+  - package-ecosystem: github-actions
+    directory: /.github/actions/setup-workspace
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      github-actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - dependencies
+      - github-actions
+
+  - package-ecosystem: github-actions
+    directory: /.github/actions/download-lace-bundle
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      github-actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - dependencies
+      - github-actions
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      prod-dependencies:
+        dependency-type: production
+        update-types: ["minor", "patch"]
+      dev-dependencies:
+        dependency-type: development
+        update-types: ["minor", "patch"]
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    labels:
+      - dependencies
+      - npm
+    # @lace-cloud/* packages are published by lace-cloud/lace;
+    # we bump them manually against monorepo releases.
+    ignore:
+      - dependency-name: "@lace-cloud/*"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,39 @@
+name: Dependabot auto-merge
+
+# Auto-merge policy for Dependabot PRs:
+#   - semver-minor + semver-patch: enable auto-merge (squash). GitHub
+#     waits for all required checks + branch-protection rules to
+#     pass before merging; we're not bypassing anything. If CI goes
+#     red, the PR stays open for human review.
+#   - semver-major: leave open for explicit review.
+#
+# Runs on `pull_request_target` so the auto-merge enablement runs
+# with write permissions from the base ref, not the (untrusted) PR
+# head. We don't check out PR code — only fetch metadata + call gh —
+# so the elevated permissions don't touch PR contents.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # v2.4.0
+
+      - name: Enable auto-merge for minor + patch
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --squash --auto "$PR_URL"


### PR DESCRIPTION
Mirrors the dependabot automation we just added to the lace monorepo. Grouped bumps per ecosystem/directory + auto-merge for minor/patch after green CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)