### PR TITLE
ci: auto-reconcile develop with main after ship-it squash-merges

### DIFF
--- a/.github/workflows/sync-develop-after-main-push.yml
+++ b/.github/workflows/sync-develop-after-main-push.yml
@@ -1,0 +1,98 @@
+name: Sync develop after main push
+
+# Ship-it policy is squash-merge develop → main. Squash flattens all of
+# develop's commits into a single new commit on main — which is NOT in
+# develop's history. Without reconciliation, every subsequent
+# develop → main PR sees conflicts (develop's commits re-apply changes
+# already present in the squash).
+#
+# This workflow reconciles automatically. On every push to main it
+# opens a PR that merges main back into develop (conflicts resolved in
+# develop's favor — develop is always the newer side by definition).
+# Once that PR lands, develop → main is a clean linear diff again.
+#
+# The PR is opened (not auto-merged) so a human can glance at the
+# reconciliation before it lands — cheap to approve, catches
+# unintended main-side changes that would otherwise silently apply
+# to develop.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    # Skip when a sync PR's own merge-to-main triggers this workflow
+    # (the sync commits already contain main-as-ancestor; re-syncing
+    # would be a no-op cycle).
+    if: "!contains(github.event.head_commit.message, 'chore: sync develop with main')"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: develop
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Check if sync is needed
+        id: check
+        run: |
+          git fetch origin main
+          if git merge-base --is-ancestor origin/main HEAD; then
+            echo "main is already an ancestor of develop — no sync needed"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create sync branch
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          BRANCH="chore/sync-develop-with-main-${GITHUB_SHA::7}"
+          echo "BRANCH=$BRANCH" >> "$GITHUB_ENV"
+          git switch -c "$BRANCH"
+          # -X ours keeps develop's content on every conflict. Safe
+          # because develop is the downstream branch; anything main
+          # has that develop needs should've come via an earlier
+          # develop→main PR (and thus already be on develop).
+          git merge origin/main --no-ff -X ours \
+            -m "chore: sync develop with main (post-ship-it reconcile)"
+
+      - name: Push sync branch
+        if: steps.check.outputs.skip != 'true'
+        run: git push -u origin "$BRANCH"
+
+      - name: Open sync PR
+        if: steps.check.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --base develop \
+            --head "$BRANCH" \
+            --title "chore: sync develop with main (post-ship-it reconcile)" \
+            --body "$(cat <<EOF
+          Automated post-ship-it reconciliation.
+
+          Ship-it PRs are squash-merged, which flattens develop's
+          commits into a single new commit on main that isn't in
+          develop's history. This PR merges main back into develop so
+          main becomes a strict ancestor again, preventing the next
+          develop → main PR from showing spurious CONFLICTING state.
+
+          Resolved conflicts with develop's side (\`-X ours\`). Review
+          the file diff is empty or limited to trivially expected
+          changes before merging.
+
+          Triggered by push to main: \`${GITHUB_SHA}\`.
+          EOF
+          )"


### PR DESCRIPTION
## Summary

Mirrors the `sync-develop-after-main-push.yml` workflow just added to `lace-cloud/lace` (PR #146). Same structural reason.

## Why

Ship-it policy is squash-merge `develop → main`. Squash flattens develop's commits into a single new commit on main that isn't in develop's history. Every subsequent `develop → main` PR then sees CONFLICTING state until main is merged back into develop.

Extension releases follow the same flow (feature → develop → main) and hit the same divergence every ship-it.

## How it works

1. Push to main triggers the workflow (including the `release.yml` publish path — they run in parallel, independent workflows).
2. Workflow checks out `develop` at full depth.
3. `git merge-base --is-ancestor origin/main HEAD` — if main is already an ancestor, skip (no-op).
4. Otherwise create `chore/sync-develop-with-main-<sha>` branch, merge `origin/main` into it with `--no-ff -X ours`, push, and open a PR back to develop.
5. PR is opened (not auto-merged) so a human can glance at the reconciliation before it lands.

## Test plan
- [ ] Merge this PR to develop.
- [ ] Next extension release (develop → main squash) fires the workflow.
- [ ] Sync PR opens within ~30s.
- [ ] Subsequent develop → main PRs show clean linear diffs instead of CONFLICTING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)