### PR TITLE
ci: skip host-e2e on Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,16 @@ jobs:
   host-e2e:
     # VS Code Electron tests need a display; xvfb-run wraps the test
     # command to provide one on the headless CI host.
+    #
+    # Skipped for Dependabot PRs. GitHub withholds Actions secrets from
+    # Dependabot-opened PRs by design (prevents a compromised transitive
+    # dep from exfiltrating credentials). host-e2e pulls the lace CLI
+    # test bundle from a private R2 bucket — without those secrets the
+    # step fails hard. Dependabot bumps only touch action refs and
+    # package versions; lint + unit-tests provide sufficient signal, and
+    # the first human-authored develop push after merge re-runs host-e2e
+    # with full secrets before anything reaches main.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:
@@ -91,9 +101,11 @@ jobs:
     steps:
       - name: Assert upstream jobs succeeded
         run: |
+          # host-e2e is allowed to be 'skipped' (Dependabot PRs only).
+          # lint + unit-tests must always succeed.
           if [ "${{ needs.lint.result }}" != "success" ] || \
              [ "${{ needs.unit-tests.result }}" != "success" ] || \
-             [ "${{ needs.host-e2e.result }}" != "success" ]; then
+             { [ "${{ needs.host-e2e.result }}" != "success" ] && [ "${{ needs.host-e2e.result }}" != "skipped" ]; }; then
             echo "::error::CI failed (lint=${{ needs.lint.result }}, unit-tests=${{ needs.unit-tests.result }}, host-e2e=${{ needs.host-e2e.result }})"
             exit 1
           fi


### PR DESCRIPTION
## Summary

`host-e2e` in `ci.yml` now skips when `github.actor == 'dependabot[bot]'`. `ci-summary` accepts `skipped` for `host-e2e` (everything else must be `success`).

## Why

Dependabot PRs don't have access to Actions secrets (GitHub security default — see [Accessing secrets](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#accessing-secrets)). `host-e2e` pulls the lace CLI test bundle from a private R2 bucket using `R2_ACCOUNT_ID`, `R2_TEST_BUNDLE_BUCKET`, `R2_TEST_BUNDLE_READ_ACCESS_KEY_ID`, `R2_TEST_BUNDLE_READ_SECRET_ACCESS_KEY` — all empty in a Dependabot-triggered run. Result: endpoint URL `https://.r2.cloudflarestorage.com`, aws CLI hard-fails, ci-summary fails, auto-merge can't fire.

PRs blocked on this: #114 (pnpm/action-setup 4→6), #115 (github-actions group with 8 updates).

## Why this is safe

Dependabot only changes action pins and package versions. Nothing in its bumps can break the extension-CLI wire contract that `host-e2e` validates. The risk profile is:

- **Caught by lint**: workflow yaml regressions.
- **Caught by unit-tests**: any package regression that breaks vitest.
- **Only host-e2e catches**: runtime CLI integration — but no dependabot bump would touch that.

The first human-authored develop push after a dependabot merge re-runs `host-e2e` with full secrets, before anything reaches main. If a bump genuinely broke host-e2e, we'd catch it there, revert, and investigate.

## Alternative considered

Populating Dependabot secrets (`gh secret set --app dependabot`) would give host-e2e access on Dependabot PRs. Not done here because (a) it duplicates the Actions secret maintenance burden, (b) it expands the credential exposure surface specifically to the scenario GitHub designed the split to protect against.

## Test plan
- [ ] Merge this PR.
- [ ] Rebase #114, #115 on new develop.
- [ ] `host-e2e` shows as `skipped`, `ci-summary` passes, auto-merge fires.
- [ ] Human PR to develop runs host-e2e normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)