### PR TITLE
chore(release): v0.0.33 — CI automation bumps

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lace-cloud",
   "displayName": "Lace Cloud",
   "description": "",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "packageManager": "pnpm@10.29.3",
   "publisher": "LaceCloudInc",
   "repository": {


### PR DESCRIPTION
## Summary

Version bump 0.0.32 → 0.0.33 for the next develop → main ship.

What ships in v0.0.33:
- #113 sync-develop-after-main-push workflow
- #111 Dependabot grouping + auto-merge
- #114 pnpm/action-setup 4 → 6
- #115 github-actions group (8 updates)
- #116 skip host-e2e on Dependabot PRs

No runtime extension changes; all CI/infra hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)