### PR TITLE
ci: publish Marketplace pre-release on every develop push

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,92 @@
+name: Pre-release
+
+# Publishes a Marketplace pre-release on every develop push that
+# touches extension source. Users who opt into "Switch to Pre-Release
+# Version" in VS Code receive these builds automatically. Stable users
+# are unaffected.
+#
+# Version scheme: ${STABLE_MAJOR}.${STABLE_MINOR}.${GITHUB_RUN_ID}.
+# github.run_id is a 64-bit monotonic counter (~10^10), always higher
+# than any stable patch (0-999). When stable bumps minor/major, SemVer
+# ordering means the new stable beats all old pre-release patches —
+# pre-release users auto-upgrade to the new stable at that point.
+#
+# No tests re-run: ci.yml on PRs to develop already validated this
+# commit. Same trust model as lace's libs-publish-next.
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - 'src/**'
+      - 'packages/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'rspack*.config.js'
+      - 'tsconfig*.json'
+      - '.github/workflows/pre-release.yml'
+
+concurrency:
+  group: pre-release
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup-workspace
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute pre-release version
+        id: version
+        run: |
+          BASE=$(jq -r .version package.json)
+          IFS='.' read -r MAJOR MINOR _ <<< "$BASE"
+          PRE_VERSION="${MAJOR}.${MINOR}.${GITHUB_RUN_ID}"
+          echo "base=$BASE"
+          echo "prerelease=$PRE_VERSION"
+          echo "version=$PRE_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Stamp pre-release version
+        # Ephemeral — not committed. Same pattern as lace's libs-publish-next.
+        run: pnpm version "${{ steps.version.outputs.version }}" --no-git-tag-version --allow-same-version
+
+      - name: Build extension bundles
+        run: pnpm run build
+
+      - name: Package .vsix
+        run: |
+          npx @vscode/vsce package --no-dependencies --pre-release \
+            --out "lace-cloud-prerelease-${{ steps.version.outputs.version }}.vsix"
+
+      - name: Publish pre-release to Marketplace
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: |
+          npx @vscode/vsce publish --pre-release \
+            --packagePath "lace-cloud-prerelease-${{ steps.version.outputs.version }}.vsix" \
+            --no-dependencies
+
+      - name: Emit summary
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          {
+            echo "### Pre-release published"
+            echo ""
+            echo "Version: \`$VERSION\`"
+            echo "Channel: Pre-Release (opt-in via VS Code Marketplace)"
+            echo ""
+            echo "Install in VS Code:"
+            echo "1. Open the Extensions panel."
+            echo "2. Find \"Lace Cloud\"."
+            echo "3. Dropdown next to Install/Update → \"Switch to Pre-Release Version\"."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,23 +83,43 @@ The repo is ruleset-gated into a three-step promotion path:
 - **Feature branches** branch off `develop`, PR to `develop`. `ci.yml` runs
   lint + unit-tests + host-e2e + `ci-summary`. `ci-summary` is the required
   status check; direct pushes to `develop` are blocked.
-- **`develop`** is the long-lived integration branch. Visual regression for
-  shared library code (Chromatic) + flow-test integration (Playwright) live
-  in lace-core's CI now — this repo's `develop` push doesn't run them.
+- **`develop`** is the long-lived integration branch. On every push that
+  touches extension source, `pre-release.yml` publishes a Marketplace
+  pre-release (see "Shipping" below). Visual regression for shared
+  library code lives in lace's CI, not here.
 - **`main`** accepts PRs only from `develop`. One required status check:
   `Release / version-bumped` (fails if `package.json` version hasn't moved
   vs `main`). Direct pushes blocked.
 - **Push to `main`** triggers `release.yml`'s release path: build, package,
   tag, `vsce publish`, GitHub Release with `.vsix` attached.
 
-### Shipping a New Version
+### Shipping
 
-1. On your feature branch, run `pnpm version patch` (or `minor` / `major`).
-   Commit the `package.json` change.
-2. PR → `develop`. `ci.yml` runs. Merge.
-3. Open `develop` → `main` PR. `version-bumped` passes (step 1 bumped it).
-   Merge.
-4. `release.yml` auto-ships: tag, Marketplace publish, GitHub Release.
+Two channels, two cadences:
+
+- **Pre-release (automatic)** — every push to develop that changes extension
+  source fires `pre-release.yml`, which publishes
+  `<major>.<minor>.<github.run_id>` to Marketplace's pre-release channel.
+  Users who enable "Switch to Pre-Release Version" on Lace Cloud in VS Code
+  pick it up automatically. No human action required. The version stamp is
+  ephemeral — not committed back to the repo.
+- **Stable (deliberate)** — the normal flow:
+  1. On your feature branch, `pnpm version patch` (or `minor` / `major`).
+     Commit the `package.json` change.
+  2. PR → `develop`. `ci.yml` runs. Merge. (The merge also fires
+     `pre-release.yml`, publishing a pre-release at the bumped base —
+     that's fine, pre-release users get an early look.)
+  3. Open `develop` → `main` PR. `version-bumped` passes (step 1 bumped it).
+     Merge.
+  4. `release.yml` auto-ships: tag, Marketplace stable publish, GitHub
+     Release with `.vsix` attached.
+
+No version convention constraints — `pnpm version` just works. Pre-release
+versions use `github.run_id` as patch (10-digit integers), which is always
+higher than a stable patch (0-999) but loses to any stable minor/major
+bump in SemVer ordering. Marketplace routes users correctly: stable
+channel sees the latest stable; pre-release channel sees the maximum of
+(latest stable, latest pre-release).
 
 ### Bumping `@lace-cloud/*` library versions
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ npx tsc --noEmit        # typecheck
 src/                    — extension activation, canvas + chat webview entries, vscode-coupled host primitives
 packages/chat-sidebar/  — VS Code chat adapter (ChatViewProvider, vscode-adapter, controller)
 packages/host-e2e/      — VS Code integration tests
-.github/                — CI (lint + unit + host-e2e), release workflow, GHCR Dockerfile
+.github/                — CI (lint + unit + host-e2e), pre-release + release workflows, GHCR Dockerfile
 ```
 
 For `lace-core` development (the libraries themselves), see


### PR DESCRIPTION
## Summary

Closes the dogfooding gap between \`develop\` and \`main\` on the extension side. Mirrors lace's \`libs-publish-next\` for the extension:

- Trigger: \`push: branches: [develop]\`, path-filtered to extension source.
- Version: \`<stable.major>.<stable.minor>.<github.run_id>\`. run_id is ~10^10, always beats stable patch. Stable minor/major bumps beat old pre-release patches per SemVer — pre-release users auto-upgrade to stable when it leapfrogs.
- Publishes with \`vsce publish --pre-release\`. Users who toggle "Switch to Pre-Release Version" on Lace Cloud pick it up automatically.

## Why

Lace publishes \`@next\` libs + CLI test bundle on every develop push so the extension can consume pre-release state. The symmetric gap — no way for extension users to consume the extension's pre-release state — is what this closes.

## What does NOT change

- No test re-run on develop push. \`ci.yml\` on the PR is the correctness gate. Same trust model as \`libs-publish-next\`.
- No new secrets. \`VSCE_PAT\` already exists for \`release.yml\`.
- No new helper scripts, no version convention constraints on stable. \`pnpm version patch|minor|major\` works as before.
- \`release.yml\` untouched. Stable channel still ships via develop → main per the existing flow.

## Test plan

- [ ] \`ci-summary\` green on this PR
- [ ] After merge, \`pre-release.yml\` fires and publishes \`0.0.<run_id>\` to Marketplace
- [ ] Pre-release version appears in Marketplace version history with the pre-release badge
- [ ] Switching a VS Code install to pre-release channel pulls down the new version; stable users (no toggle) still see 0.0.33

🤖 Generated with [Claude Code](https://claude.com/claude-code)