### PR TITLE
fix(pre-release): use run_number + stable_patch (run_id exceeds 2^31)

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -5,11 +5,17 @@ name: Pre-release
 # Version" in VS Code receive these builds automatically. Stable users
 # are unaffected.
 #
-# Version scheme: ${STABLE_MAJOR}.${STABLE_MINOR}.${GITHUB_RUN_ID}.
-# github.run_id is a 64-bit monotonic counter (~10^10), always higher
-# than any stable patch (0-999). When stable bumps minor/major, SemVer
-# ordering means the new stable beats all old pre-release patches —
-# pre-release users auto-upgrade to the new stable at that point.
+# Version scheme: ${STABLE_MAJOR}.${STABLE_MINOR}.$((STABLE_PATCH + GITHUB_RUN_NUMBER)).
+# Marketplace caps each version component at 2^31 - 1, so github.run_id
+# (10-digit) doesn't fit. github.run_number is a workflow-local
+# monotonic counter starting at 1; adding the current stable patch
+# gives a pre-release patch that's always > stable patch and stays
+# well within the 32-bit limit for a very long time.
+#
+# When stable bumps minor/major, SemVer ordering means the new stable
+# beats all old pre-release patches — pre-release users auto-upgrade to
+# the new stable at that point. When stable patch bumps, the next
+# pre-release recomputes from the new base (higher floor).
 #
 # No tests re-run: ci.yml on PRs to develop already validated this
 # commit. Same trust model as lace's libs-publish-next.
@@ -49,8 +55,9 @@ jobs:
         id: version
         run: |
           BASE=$(jq -r .version package.json)
-          IFS='.' read -r MAJOR MINOR _ <<< "$BASE"
-          PRE_VERSION="${MAJOR}.${MINOR}.${GITHUB_RUN_ID}"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE"
+          NEW_PATCH=$((PATCH + GITHUB_RUN_NUMBER))
+          PRE_VERSION="${MAJOR}.${MINOR}.${NEW_PATCH}"
           echo "base=$BASE"
           echo "prerelease=$PRE_VERSION"
           echo "version=$PRE_VERSION" >> "$GITHUB_OUTPUT"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,10 +99,10 @@ Two channels, two cadences:
 
 - **Pre-release (automatic)** — every push to develop that changes extension
   source fires `pre-release.yml`, which publishes
-  `<major>.<minor>.<github.run_id>` to Marketplace's pre-release channel.
-  Users who enable "Switch to Pre-Release Version" on Lace Cloud in VS Code
-  pick it up automatically. No human action required. The version stamp is
-  ephemeral — not committed back to the repo.
+  `<major>.<minor>.<stable_patch + github.run_number>` to Marketplace's
+  pre-release channel. Users who enable "Switch to Pre-Release Version" on
+  Lace Cloud in VS Code pick it up automatically. No human action required.
+  The version stamp is ephemeral — not committed back to the repo.
 - **Stable (deliberate)** — the normal flow:
   1. On your feature branch, `pnpm version patch` (or `minor` / `major`).
      Commit the `package.json` change.
@@ -115,11 +115,12 @@ Two channels, two cadences:
      Release with `.vsix` attached.
 
 No version convention constraints — `pnpm version` just works. Pre-release
-versions use `github.run_id` as patch (10-digit integers), which is always
-higher than a stable patch (0-999) but loses to any stable minor/major
-bump in SemVer ordering. Marketplace routes users correctly: stable
-channel sees the latest stable; pre-release channel sees the maximum of
-(latest stable, latest pre-release).
+patch = stable patch + `github.run_number` (workflow-local monotonic
+counter), which is always > stable patch and stays within Marketplace's
+32-bit-int-per-component cap. Stable minor/major bumps beat any old
+pre-release patch in SemVer ordering, so Marketplace routes users
+correctly: stable channel sees the latest stable; pre-release channel
+sees the maximum of (latest stable, latest pre-release).
 
 ### Bumping `@lace-cloud/*` library versions
 


### PR DESCRIPTION
## Summary

First \`pre-release.yml\` run ([24869212173](https://github.com/lace-cloud/vs-code-extension/actions/runs/24869212173)) failed at vsce publish with:

> The version string '0.0.24869212173' doesn't conform to the requirements for a version. It must be one to four numbers in the range 0 to 2147483647 [...]

Marketplace enforces a 32-bit int cap per version component. \`github.run_id\` is a 64-bit counter (~10^10) that exceeds 2^31 (~2.1 × 10^9).

## Fix

Switch to \`github.run_number\` (workflow-local monotonic counter, starts at 1) added to the current stable patch:

\`\`\`
pre-release patch = stable_patch + github.run_number
\`\`\`

- Always > stable patch (run_number ≥ 1)
- Stays within 32-bit cap for billions of runs
- SemVer routing semantics unchanged: stable minor/major bumps still beat any old pre-release patch

For current stable 0.0.33, run 1 → 0.0.34, run 2 → 0.0.35, etc. When stable bumps to 0.0.50, next pre-release recomputes: 0.0.50 + run_number → well above 0.0.50.

## Test plan

- [ ] \`ci-summary\` green on this PR
- [ ] After merge, the next develop push fires \`pre-release.yml\` successfully and publishes a valid Marketplace pre-release version

🤖 Generated with [Claude Code](https://claude.com/claude-code)