### PR TITLE
chore: bump 0.0.34 → 0.0.35

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lace-cloud",
   "displayName": "Lace Cloud",
   "description": "",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "packageManager": "pnpm@10.29.3",
   "publisher": "LaceCloudInc",
   "repository": {


### PR DESCRIPTION
Version bump to ship the PR #129 CI-only changes (public release CLI integration) to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)