### PR TITLE
chore: bump 0.0.35 → 0.0.41 (pre-release burned the lower patches)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lace-cloud",
   "displayName": "Lace Cloud",
   "description": "",
-  "version": "0.0.35",
+  "version": "0.0.41",
   "packageManager": "pnpm@10.29.3",
   "publisher": "LaceCloudInc",
   "repository": {


### PR DESCRIPTION
## Why

PR #131's stable publish failed — Marketplace shares the version namespace across pre-release and stable channels, and pre-release.yml had already published 0.0.35 / 0.0.37 / 0.0.38 / 0.0.40. Stable can't reuse any of those slots.

## Fix

Bump stable patch past the highest existing pre-release (0.0.40) → **0.0.41**.

## Follow-up (separate PR)

Rework pre-release versioning so the two channels can't collide again — VS Code recommends even minor for stable, odd minor for pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)