### PR TITLE
develop → main: v0.0.41 release-CLI integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lace-cloud",
   "displayName": "Lace Cloud",
   "description": "",
-  "version": "0.0.35",
+  "version": "0.0.41",
   "packageManager": "pnpm@10.29.3",
   "publisher": "LaceCloudInc",
   "repository": {


### PR DESCRIPTION
## Summary

Reships PR #131's payload (release-CLI integration tests) at a stable patch Marketplace hasn't seen.

- PR #131 bumped to 0.0.35 and merged to main, but release.yml failed: Marketplace shares the version namespace across pre-release and stable channels, and pre-release.yml had already published 0.0.35 / 0.0.37 / 0.0.38 / 0.0.40.
- PR #132 bumped past the burned range → 0.0.41.

## Follow-up

Rework pre-release versioning so the two channels can't collide again (VS Code convention: even minor = stable, odd minor = pre-release).

## Test plan

- [ ] `Release Guard / version-bumped` passes.
- [ ] On merge, `release.yml` auto-publishes stable v0.0.41 to Marketplace and attaches .vsix to the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)