### PR TITLE
develop → main: v0.2.0 — even/odd minor versioning

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -5,17 +5,23 @@ name: Pre-release
 # Version" in VS Code receive these builds automatically. Stable users
 # are unaffected.
 #
-# Version scheme: ${STABLE_MAJOR}.${STABLE_MINOR}.$((STABLE_PATCH + GITHUB_RUN_NUMBER)).
-# Marketplace caps each version component at 2^31 - 1, so github.run_id
-# (10-digit) doesn't fit. github.run_number is a workflow-local
-# monotonic counter starting at 1; adding the current stable patch
-# gives a pre-release patch that's always > stable patch and stays
-# well within the 32-bit limit for a very long time.
+# Version scheme: VS Code's documented convention — stable uses even
+# minors, pre-release uses odd minors, same major/patch namespace shared
+# with stable but structurally non-overlapping.
 #
-# When stable bumps minor/major, SemVer ordering means the new stable
-# beats all old pre-release patches — pre-release users auto-upgrade to
-# the new stable at that point. When stable patch bumps, the next
-# pre-release recomputes from the new base (higher floor).
+#   https://code.visualstudio.com/api/working-with-extensions/publishing-extension
+#
+#   stable:      <major>.<EVEN>.<patch>          e.g. 0.2.0, 0.2.3, 0.4.0
+#   pre-release: <major>.<EVEN+1>.<run_number>   e.g. 0.3.7, 0.3.8, 0.3.9
+#
+# SemVer ordering gives the user-facing behaviour for free: when
+# stable bumps minor (0.2.x → 0.4.0), pre-release users auto-upgrade
+# because 0.4.0 > 0.3.anything. Stable patch bumps (0.2.x → 0.2.x+1)
+# stay below pre-release, so pre-release users keep the newer build.
+#
+# github.run_number is a workflow-local monotonic counter starting at 1.
+# It gives each pre-release a unique, strictly increasing patch. Stays
+# well within Marketplace's 32-bit-per-component cap for decades.
 #
 # No tests re-run: ci.yml on PRs to develop already validated this
 # commit. Same trust model as lace's libs-publish-next.
@@ -54,10 +60,19 @@ jobs:
       - name: Compute pre-release version
         id: version
         run: |
+          set -euo pipefail
           BASE=$(jq -r .version package.json)
           IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE"
-          NEW_PATCH=$((PATCH + GITHUB_RUN_NUMBER))
-          PRE_VERSION="${MAJOR}.${MINOR}.${NEW_PATCH}"
+          # Invariant: stable must live on even minors. If this fails, the
+          # stable-side guard (release-guard.yml) was bypassed and needs
+          # fixing — do not publish a pre-release that would collide with
+          # stable's lane.
+          if [ $((MINOR % 2)) -ne 0 ]; then
+            echo "::error::package.json minor is $MINOR (odd); stable must use even minor per VS Code convention."
+            exit 1
+          fi
+          PRE_MINOR=$((MINOR + 1))
+          PRE_VERSION="${MAJOR}.${PRE_MINOR}.${GITHUB_RUN_NUMBER}"
           echo "base=$BASE"
           echo "prerelease=$PRE_VERSION"
           echo "version=$PRE_VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-guard.yml
+++ b/.github/workflows/release-guard.yml
@@ -1,8 +1,14 @@
 name: Release Guard
 
-# Gate on PRs to main. Fails if package.json version hasn't moved vs
-# the base branch, forcing every develop → main PR to include a
-# `pnpm version` bump. Main's ruleset requires this check.
+# Gate on PRs to main. Two assertions:
+#
+#   1. package.json version was bumped vs the base branch.
+#   2. New version's minor is EVEN. Stable lives on even minors per the
+#      VS Code pre-release convention; pre-release (published from
+#      develop) lives on odd minors. Letting stable publish an odd
+#      minor would burn a future pre-release slot.
+#
+# https://code.visualstudio.com/api/working-with-extensions/publishing-extension
 #
 # Separate from release.yml so each workflow file has one purpose:
 #   release-guard.yml (this) — PR gate, no shipping
@@ -25,13 +31,24 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Assert package.json version was bumped vs base
+      - name: Assert version was bumped and uses even minor
         run: |
+          set -euo pipefail
           HEAD_VERSION=$(jq -r .version package.json)
           BASE_VERSION=$(git show "origin/${{ github.base_ref }}:package.json" | jq -r .version)
+
           if [ "$HEAD_VERSION" = "$BASE_VERSION" ]; then
             echo "::error::package.json version must be bumped on PRs to main ($HEAD_VERSION unchanged vs ${{ github.base_ref }})."
-            echo "Run \`pnpm version patch\` (or minor/major) on your branch, commit, push."
+            echo "Run \`pnpm version patch\` (or \`pnpm version <M>.<N+2>.0 --no-git-tag-version\` for a minor bump) on your branch, commit, push."
             exit 1
           fi
-          echo "Version bump: $BASE_VERSION → $HEAD_VERSION"
+
+          IFS='.' read -r _ MINOR _ <<< "$HEAD_VERSION"
+          if [ $((MINOR % 2)) -ne 0 ]; then
+            echo "::error::package.json minor is $MINOR (odd). Stable must use even minor per VS Code convention."
+            echo "Odd minors are reserved for the pre-release channel (published from develop)."
+            echo "For a minor bump, run: pnpm version <MAJOR>.$((MINOR + 1)).0 --no-git-tag-version"
+            exit 1
+          fi
+
+          echo "Version bump: $BASE_VERSION → $HEAD_VERSION (minor $MINOR is even, OK)"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,32 +96,50 @@ The repo is ruleset-gated into a three-step promotion path:
 
 ### Shipping
 
-Two channels, two cadences:
+Two channels, two cadences, [VS Code's pre-release convention][vs-pre]:
+**stable uses even minors, pre-release uses odd minors**. Same
+Marketplace version namespace, structurally non-overlapping lanes.
 
-- **Pre-release (automatic)** — every push to develop that changes extension
-  source fires `pre-release.yml`, which publishes
-  `<major>.<minor>.<stable_patch + github.run_number>` to Marketplace's
-  pre-release channel. Users who enable "Switch to Pre-Release Version" on
-  Lace Cloud in VS Code pick it up automatically. No human action required.
-  The version stamp is ephemeral — not committed back to the repo.
+[vs-pre]: https://code.visualstudio.com/api/working-with-extensions/publishing-extension
+
+```
+stable:      0.2.0, 0.2.1, 0.2.2, …    → pnpm version patch
+             0.4.0, 0.4.1, …            → pnpm version 0.4.0 --no-git-tag-version (see below)
+pre-release: 0.3.7, 0.3.8, 0.3.9, …    → automatic, stamped as run_number
+             0.5.1, 0.5.2, …            → starts fresh when stable minor bumps
+```
+
+SemVer ordering does the routing. Pre-release users auto-upgrade to the
+new stable on a minor bump (`0.4.0 > 0.3.anything`). Stable patch bumps
+stay below the pre-release lane (`0.2.1 < 0.3.N`), so pre-release users
+keep the newer build.
+
+- **Pre-release (automatic)** — every push to develop that changes
+  extension source fires `pre-release.yml`, which publishes
+  `<major>.<stable_minor + 1>.<github.run_number>` to Marketplace's
+  pre-release channel. Users who enable "Switch to Pre-Release Version"
+  on Lace Cloud in VS Code pick it up automatically. No human action
+  required. The version stamp is ephemeral — not committed back to the
+  repo.
 - **Stable (deliberate)** — the normal flow:
-  1. On your feature branch, `pnpm version patch` (or `minor` / `major`).
+  1. On your feature branch, bump `package.json`:
+     - Patch: `pnpm version patch` (0.2.5 → 0.2.6).
+     - Minor: `pnpm version <MAJOR>.<MINOR+2>.0 --no-git-tag-version`
+       (e.g. from `0.2.x`, run `pnpm version 0.4.0 --no-git-tag-version`).
+       `pnpm version minor` would produce an odd minor, which is on the
+       pre-release lane — `Release Guard / version-bumped` rejects it.
      Commit the `package.json` change.
   2. PR → `develop`. `ci.yml` runs. Merge. (The merge also fires
-     `pre-release.yml`, publishing a pre-release at the bumped base —
+     `pre-release.yml`, publishing a pre-release on the odd-minor lane —
      that's fine, pre-release users get an early look.)
-  3. Open `develop` → `main` PR. `version-bumped` passes (step 1 bumped it).
-     Merge.
+  3. Open `develop` → `main` PR. `version-bumped` passes (step 1 bumped
+     it to an even minor). Merge.
   4. `release.yml` auto-ships: tag, Marketplace stable publish, GitHub
      Release with `.vsix` attached.
 
-No version convention constraints — `pnpm version` just works. Pre-release
-patch = stable patch + `github.run_number` (workflow-local monotonic
-counter), which is always > stable patch and stays within Marketplace's
-32-bit-int-per-component cap. Stable minor/major bumps beat any old
-pre-release patch in SemVer ordering, so Marketplace routes users
-correctly: stable channel sees the latest stable; pre-release channel
-sees the maximum of (latest stable, latest pre-release).
+`github.run_number` is a workflow-local monotonic counter that gives
+each pre-release a unique, strictly increasing patch; stays well within
+Marketplace's 32-bit-per-component cap for decades.
 
 ### Bumping `@lace-cloud/*` library versions
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lace-cloud",
   "displayName": "Lace Cloud",
   "description": "",
-  "version": "0.0.41",
+  "version": "0.2.0",
   "packageManager": "pnpm@10.29.3",
   "publisher": "LaceCloudInc",
   "repository": {


### PR DESCRIPTION
Ships PR #134 to Marketplace stable as v0.2.0. Adopts VS Code's even/odd minor convention so stable and pre-release can't collide.

Previous stable was 0.0.41 (collision-forced bump after pre-release burned 0.0.35); 0.2.0 is the first even-minor on the new scheme. Pre-release just published 0.3.7 on the new odd-minor lane — confirmed working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)