### PR TITLE
ci: workflow hygiene — permissions, stale comment, idempotent tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  packages: read  # @lace-cloud/* fetch from GH Packages
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,9 +57,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # setup-workspace installs deps AND runs proto:gen — the latter is
-      # critical: generated proto is gitignored, so rspack (invoked by
-      # vsce:prepublish) would fail on missing imports without it.
       - uses: ./.github/actions/setup-workspace
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -74,11 +71,20 @@ jobs:
 
       - name: Create Git tag
         run: |
+          set -euo pipefail
           VERSION="${{ needs.check-version.outputs.version }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "v$VERSION" -m "Release v$VERSION"
-          git push origin "v$VERSION"
+          # Idempotent: a prior run may have pushed the tag before
+          # failing on a later step (e.g., Marketplace publish).
+          # A workflow re-run then hits "tag already exists"; skip
+          # cleanly and let the remaining steps re-attempt.
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "Tag v$VERSION already exists locally; skipping tag step."
+          else
+            git tag -a "v$VERSION" -m "Release v$VERSION"
+            git push origin "v$VERSION"
+          fi
 
       - name: Publish to VS Code Marketplace
         run: npx @vscode/vsce publish --packagePath lace-cloud.vsix --no-dependencies


### PR DESCRIPTION
Three low-severity findings from an independent review of the workflows:

- **`ci.yml`**: add explicit `permissions: { contents: read, packages: read }` at the workflow level. Was relying on GH's default (writable on push, restricted on PR). No job needs write.
- **`release.yml`**: remove stale comment claiming `setup-workspace` runs `proto:gen`. It doesn't — the extension consumes generated protos from `@lace-cloud/proto`, nothing is regenerated here.
- **`release.yml`**: guard the `git tag` step so a workflow re-run after a partial failure (tag pushed, Marketplace publish failed) skips cleanly instead of erroring on "tag already exists".

No version bump — `release.yml` changes only take effect when the workflow runs on main. These will ride to main with the next substantive stable ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)