### PR TITLE
chore: bump version 0.2.0 → 0.4.0 for next stable ship

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lace-cloud",
   "displayName": "Lace Cloud",
   "description": "",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "packageManager": "pnpm@10.29.3",
   "publisher": "LaceCloudInc",
   "repository": {


### PR DESCRIPTION
## Summary

Bumps `package.json` from `0.2.0` → `0.4.0`. Once this lands on `develop`, the follow-up `develop → main` PR will have the bumped version `release-guard.yml` requires, kicking off the stable Marketplace ship.

Skipping `0.3.x` per [VS Code's pre-release minor convention][vs-pre]: stable on even minors, pre-release on odd. `release-guard.yml` enforces the even-minor rule on PRs to `main`.

[vs-pre]: https://code.visualstudio.com/api/working-with-extensions/publishing-extension

The develop→main promotion will bundle:
- PR #137 — catch up `@lace-cloud/*` 0.1.2 → 0.6.5 + migrate off GH Packages
- PR #136 — workflow hygiene (permissions, stale comment, idempotent tag)

Picking minor (+2) over patch because users see five months of library work for the first time on stable: canvas rebuild, DS Evolution arcs, policy preview UI, npmjs.org migration.

## Test plan

- [x] `pnpm version 0.4.0 --no-git-tag-version` produces 0.4.0
- [ ] CI green (lint + unit + host-e2e + ci-summary)
- [ ] After merge, develop→main PR clears `Release Guard / version-bumped`
- [ ] `release.yml` auto-ships on push to main (build, tag `v0.4.0`, `vsce publish` stable, GitHub Release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)